### PR TITLE
Fix cargo fmt and editorconfig violations

### DIFF
--- a/crates/arc/src/auth_results.rs
+++ b/crates/arc/src/auth_results.rs
@@ -93,7 +93,10 @@ impl AuthResultsValue {
             out.push_str(&format!(" reason={reason:?}"));
         }
         for prop in &self.properties {
-            out.push_str(&format!("\n    {}.{}={}", prop.ptype, prop.property, prop.value));
+            out.push_str(&format!(
+                "\n    {}.{}={}",
+                prop.ptype, prop.property, prop.value
+            ));
         }
         out
     }

--- a/crates/arc/src/chain.rs
+++ b/crates/arc/src/chain.rs
@@ -169,4 +169,3 @@ impl ChainValidator {
         )
     }
 }
-

--- a/crates/arc/src/lib.rs
+++ b/crates/arc/src/lib.rs
@@ -15,11 +15,11 @@
 //! a set of three header fields, called an **ARC Set**, identified by an
 //! instance number `i` starting at 1 and incrementing at each hop:
 //!
-//! | Header | Tag | Purpose |
-//! |--------|-----|---------|
-//! | `ARC-Authentication-Results` (AAR) | `i=`, `authserv-id=` | Authentication results at this hop (SPF, DKIM, DMARC, ARC) |
-//! | `ARC-Message-Signature` (AMS) | `i=`, same tags as DKIM-Signature | DKIM-like signature of the message as received at this hop |
-//! | `ARC-Seal` (AS) | `i=`, `cv=`, same algorithm tags | Signature over the entire ARC chain up to this hop |
+//! | Header (abbr) | Key tags | Purpose |
+//! |---------------|----------|---------|
+//! | ARC-Authentication-Results (AAR) | `i=`, `authserv-id=` | Auth results at this hop |
+//! | ARC-Message-Signature (AMS) | `i=`, DKIM-Signature tags | Message signature at this hop |
+//! | ARC-Seal (AS) | `i=`, `cv=`, algorithm | Seals the full ARC chain |
 //!
 //! The header ordering requirement (RFC 8617 §5.1): ARC-Authentication-Results
 //! MUST be added before ARC-Message-Signature, which MUST be added before

--- a/crates/dkim/src/lib.rs
+++ b/crates/dkim/src/lib.rs
@@ -52,10 +52,10 @@
 //!
 //! Two algorithms apply independently to headers and body:
 //!
-//! | Algorithm | Headers | Body |
-//! |-----------|---------|------|
-//! | `simple`  | Field names and values unchanged | Trailing empty lines removed; single CRLF appended |
-//! | `relaxed` | Names lowercased; value WSP normalised | Line-internal WSP collapsed; trailing WSP removed; trailing empty lines removed; single CRLF appended |
+//! | Algorithm | Header treatment | Body treatment |
+//! |-----------|-----------------|----------------|
+//! | `simple`  | Names and values unchanged | Strip trailing CRLFs; append one CRLF |
+//! | `relaxed` | Lowercase names; normalise WSP | Compress WSP; strip trailing; append CRLF |
 //!
 //! The `c=` tag encodes `<header>/<body>`, e.g. `relaxed/relaxed`.
 //!

--- a/crates/lmtp/src/codec.rs
+++ b/crates/lmtp/src/codec.rs
@@ -63,7 +63,9 @@ pub struct CommandCodec {
 impl CommandCodec {
     /// Construct a [`CommandCodec`] with the default command-line length limit.
     pub fn new() -> Self {
-        Self { max_line: MAX_COMMAND_LINE }
+        Self {
+            max_line: MAX_COMMAND_LINE,
+        }
     }
 }
 

--- a/crates/lmtp/src/response.rs
+++ b/crates/lmtp/src/response.rs
@@ -85,7 +85,10 @@ impl ReplyCode {
     ///
     /// Panics if `code` is not in `200..=599`.
     pub fn new(code: u16) -> Self {
-        assert!((200..=599).contains(&code), "reply code out of range: {code}");
+        assert!(
+            (200..=599).contains(&code),
+            "reply code out of range: {code}"
+        );
         ReplyCode(code)
     }
 
@@ -161,7 +164,10 @@ impl Reply {
 
     /// `220 <hostname> LMTP service ready`
     pub fn greeting(hostname: &str) -> Self {
-        Self::new(ReplyCode::SERVICE_READY, format!("{hostname} LMTP service ready"))
+        Self::new(
+            ReplyCode::SERVICE_READY,
+            format!("{hostname} LMTP service ready"),
+        )
     }
 
     /// `221 <hostname> Bye`
@@ -176,12 +182,18 @@ impl Reply {
 
     /// `354 End data with <CR><LF>.<CR><LF>`
     pub fn start_data() -> Self {
-        Self::new(ReplyCode::START_MAIL_INPUT, "End data with <CR><LF>.<CR><LF>")
+        Self::new(
+            ReplyCode::START_MAIL_INPUT,
+            "End data with <CR><LF>.<CR><LF>",
+        )
     }
 
     /// `500 Syntax error, command unrecognised`
     pub fn syntax_error() -> Self {
-        Self::new(ReplyCode::SYNTAX_ERROR, "Syntax error, command unrecognised")
+        Self::new(
+            ReplyCode::SYNTAX_ERROR,
+            "Syntax error, command unrecognised",
+        )
     }
 
     /// `503 Bad sequence of commands`

--- a/crates/lmtp/src/session.rs
+++ b/crates/lmtp/src/session.rs
@@ -188,4 +188,3 @@ impl<H: MessageHandler> Session<H> {
         )
     }
 }
-

--- a/crates/service/src/config.rs
+++ b/crates/service/src/config.rs
@@ -206,7 +206,7 @@ fn default_signed_headers() -> Vec<String> {
         "from".into(),
         "from".into(), // over-signing
         "to".into(),
-        "to".into(),   // over-signing
+        "to".into(), // over-signing
         "cc".into(),
         "subject".into(),
         "date".into(),

--- a/crates/service/src/main.rs
+++ b/crates/service/src/main.rs
@@ -55,7 +55,10 @@ use tracing_subscriber::EnvFilter;
 
 /// Command-line arguments.
 #[derive(Debug, Parser)]
-#[command(name = "lmtp-dkim", about = "LMTP DKIM-signing and ARC-sealing service")]
+#[command(
+    name = "lmtp-dkim",
+    about = "LMTP DKIM-signing and ARC-sealing service"
+)]
 struct Args {
     /// Path to the TOML configuration file.
     ///


### PR DESCRIPTION
cargo fmt reformats:
- crates/lmtp/src/codec.rs
- crates/lmtp/src/response.rs
- crates/lmtp/src/session.rs
- crates/arc/src/auth_results.rs
- crates/arc/src/chain.rs
- crates/service/src/config.rs
- crates/service/src/main.rs

Shorten Markdown table rows in doc comments that exceeded the 100-character line limit set in .editorconfig:
- crates/dkim/src/lib.rs (canonicalization table)
- crates/arc/src/lib.rs (ARC header fields table)

https://claude.ai/code/session_012DErEnd3j8np3KGEH2rJvp