### PR TITLE
Implement email-primitives (step 1)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[profile.default]
+failure-output = "immediate"
+final-status-level = "flaky"
+
+[profile.ci]
+failure-output = "immediate-final"
+final-status-level = "all"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,11 @@ jobs:
     - name: Cache build artifacts
       uses: Swatinem/rust-cache@v2
 
-    - name: cargo test
-      run: cargo test --workspace
+    - name: Install cargo-nextest
+      uses: taiki-e/install-action@nextest
+
+    - name: cargo nextest run
+      run: cargo nextest run --workspace --profile ci
 
     - name: Show Git Status
       run: git status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,16 @@ Filling in those stubs is the primary work remaining.
 
 ```sh
 cargo check --workspace --all-targets   # fast type-check
-cargo test --workspace                  # compile and run tests
+cargo nextest run --workspace           # compile and run tests
 cargo clippy --workspace --all-targets  # lint
 cargo fmt --check                       # formatting check
 cargo fmt                               # fix formatting
+```
+
+Install cargo-nextest if you don't have it:
+
+```sh
+cargo install cargo-nextest --locked
 ```
 
 Run pre-commit locally:

--- a/crates/email-primitives/src/address.rs
+++ b/crates/email-primitives/src/address.rs
@@ -28,6 +28,13 @@
 //! non-ASCII characters (RFC 5321 section 2.3.5; RFC 5891 IDNA 2008).
 //! Conversion from Unicode to Punycode is outside the scope of this crate.
 
+use winnow::{
+    ModalResult, Parser,
+    combinator::alt,
+    error::{ContextError, ErrMode},
+    token::{literal, one_of, take_while},
+};
+
 use crate::{Error, Result};
 
 /// An email address of the form `local-part@domain`.
@@ -51,8 +58,30 @@ impl EmailAddress {
     ///
     /// Returns [`Error::InvalidAddress`] if the input does not conform to the
     /// `addr-spec` grammar (RFC 5322 section 3.4.1).
-    pub fn parse(_input: &str) -> Result<Self> {
-        todo!("winnow parser for RFC 5322 addr-spec: dot-atom / quoted-string \"@\" domain")
+    pub fn parse(input: &str) -> Result<Self> {
+        // Strip surrounding whitespace and optional angle brackets.
+        let s = input.trim();
+        let s = s.strip_prefix('<').unwrap_or(s);
+        let s = s.strip_suffix('>').unwrap_or(s);
+        let s = s.trim();
+
+        // Split on the last '@' (RFC 5322 §3.4.1: local-part "@" domain).
+        let at = s
+            .rfind('@')
+            .ok_or_else(|| Error::InvalidAddress(input.to_owned()))?;
+        let local_str = &s[..at];
+        let domain_str = &s[at + 1..];
+
+        if local_str.is_empty() || domain_str.is_empty() {
+            return Err(Error::InvalidAddress(input.to_owned()));
+        }
+
+        let local =
+            parse_local_part(local_str).ok_or_else(|| Error::InvalidAddress(input.to_owned()))?;
+        let domain =
+            Domain::parse(domain_str).map_err(|_| Error::InvalidAddress(input.to_owned()))?;
+
+        Ok(EmailAddress { local, domain })
     }
 
     /// The local part (the portion to the left of `@`).
@@ -74,6 +103,90 @@ impl EmailAddress {
 impl std::fmt::Display for EmailAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}@{}", self.local, self.domain)
+    }
+}
+
+/// Returns true if `c` is an `atext` character per RFC 5322 §3.2.3.
+fn is_atext(c: char) -> bool {
+    matches!(
+        c,
+        'A'..='Z'
+        | 'a'..='z'
+        | '0'..='9'
+        | '!'
+        | '#'
+        | '$'
+        | '%'
+        | '&'
+        | '\''
+        | '*'
+        | '+'
+        | '-'
+        | '/'
+        | '='
+        | '?'
+        | '^'
+        | '_'
+        | '`'
+        | '{'
+        | '|'
+        | '}'
+        | '~'
+    )
+}
+
+/// Parse a `dot-atom` local-part: `1*atext *("." 1*atext)` (RFC 5322 §3.4.1).
+fn dot_atom<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+    // Take chars that are atext or '.', then post-validate the dot rules.
+    let result = take_while(1.., |c: char| is_atext(c) || c == '.').parse_next(input)?;
+    // RFC 5322 §3.4.1: no leading, trailing, or adjacent dots.
+    if result.starts_with('.') || result.ends_with('.') || result.contains("..") {
+        return Err(ErrMode::Backtrack(ContextError::new()));
+    }
+    Ok(result)
+}
+
+/// Parse a `quoted-string` local-part (RFC 5322 §3.4.1).
+///
+/// Grammar: `DQUOTE *(qtext / quoted-pair) DQUOTE`
+/// - `qtext` = printable ASCII excluding `\` and `"`
+/// - `quoted-pair` = `\` followed by any printable ASCII or SP/HTAB
+fn quoted_string<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
+    let start = *input;
+    // Opening quote.
+    literal("\"").parse_next(input)?;
+    loop {
+        match input.chars().next() {
+            None | Some('"') => break,
+            Some('\\') => {
+                // quoted-pair: consume backslash + one more char
+                *input = &input[1..];
+                one_of(|c: char| c.is_ascii() && (c == ' ' || c == '\t' || c.is_ascii_graphic()))
+                    .parse_next(input)?;
+            }
+            Some(c) if c != '\r' && c != '\n' && c.is_ascii() => {
+                *input = &input[c.len_utf8()..];
+            }
+            _ => {
+                return Err(winnow::error::ErrMode::Backtrack(
+                    winnow::error::ContextError::new(),
+                ));
+            }
+        }
+    }
+    // Closing quote.
+    literal("\"").parse_next(input)?;
+    let consumed = start.len() - input.len();
+    Ok(&start[..consumed])
+}
+
+/// Parse the local-part of an address (dot-atom or quoted-string).
+fn parse_local_part(s: &str) -> Option<LocalPart> {
+    let mut input = s;
+    let result = alt((dot_atom, quoted_string)).parse_next(&mut input);
+    match result {
+        Ok(matched) if input.is_empty() && matched == s => Some(LocalPart(s.to_owned())),
+        _ => None,
     }
 }
 
@@ -117,12 +230,26 @@ pub struct Domain(pub(crate) String);
 impl Domain {
     /// Parse and normalise a domain string to lowercase ASCII.
     ///
+    /// Validates label structure per RFC 1123 §2.1:
+    /// - Each label: 1–63 chars, `[A-Za-z0-9-]`, no leading or trailing hyphen.
+    /// - No empty labels (consecutive dots or trailing dot).
+    ///
     /// # Errors
     ///
     /// Returns [`Error::InvalidDomain`] if the domain is syntactically
     /// invalid.
-    pub fn parse(_input: &str) -> Result<Self> {
-        todo!("validate label structure per RFC 1123 §2.1; lowercase normalise")
+    pub fn parse(input: &str) -> Result<Self> {
+        if input.is_empty() {
+            return Err(Error::InvalidDomain(input.to_owned()));
+        }
+        // RFC 1123 §2.1: overall max 253 chars.
+        if input.len() > 253 {
+            return Err(Error::InvalidDomain(input.to_owned()));
+        }
+        for label in input.split('.') {
+            validate_label(label).map_err(|_| Error::InvalidDomain(input.to_owned()))?;
+        }
+        Ok(Domain(input.to_ascii_lowercase()))
     }
 
     /// The domain as a lowercase ASCII string, suitable for DNS queries.
@@ -148,9 +275,31 @@ impl Domain {
     /// - `"example.com".is_parent_of("sub.example.com")` → `true`
     /// - `"example.com".is_parent_of("other.com")` → `false`
     pub fn is_parent_of(&self, other: &Domain) -> bool {
-        let _ = other;
-        todo!("check other == self or other ends with .{self}")
+        // Both are already lowercase, so direct comparison is correct.
+        // The ".{self}" suffix check ensures we match at a label boundary,
+        // preventing "ample.com" from being a parent of "example.com".
+        other.0 == self.0 || other.0.ends_with(&format!(".{}", self.0))
     }
+}
+
+/// Validate a single DNS label per RFC 1123 §2.1.
+fn validate_label(label: &str) -> std::result::Result<(), ()> {
+    if label.is_empty() || label.len() > 63 {
+        return Err(());
+    }
+    let bytes = label.as_bytes();
+    if !bytes[0].is_ascii_alphanumeric() {
+        return Err(());
+    }
+    if !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
+        return Err(());
+    }
+    for &b in bytes {
+        if !b.is_ascii_alphanumeric() && b != b'-' {
+            return Err(());
+        }
+    }
+    Ok(())
 }
 
 impl std::fmt::Display for Domain {
@@ -204,5 +353,220 @@ impl std::fmt::Display for NullPath {
             NullPath::Address(addr) => write!(f, "<{addr}>"),
             NullPath::Null => f.write_str("<>"),
         }
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_address {
+    use super::*;
+
+    /// RFC 5322 §3.4.1: basic dot-atom addr-spec.
+    #[test]
+    fn parse_simple() {
+        let a = EmailAddress::parse("user@example.com").unwrap();
+        assert_eq!(a.local().as_str(), "user");
+        assert_eq!(a.domain().as_str(), "example.com");
+    }
+
+    /// RFC 5322 §3.4.1: quoted-string local part.
+    #[test]
+    fn parse_quoted_local() {
+        let a = EmailAddress::parse("\"user name\"@example.com").unwrap();
+        assert_eq!(a.local().as_str(), "\"user name\"");
+        assert_eq!(a.domain().as_str(), "example.com");
+    }
+
+    /// RFC 5322 §3.4.1: quoted-pair inside quoted local part.
+    #[test]
+    fn parse_quoted_pair_local() {
+        let a = EmailAddress::parse("\"user\\\"quoted\"@example.com").unwrap();
+        assert!(a.local().as_str().starts_with('"'));
+    }
+
+    /// RFC 5321 §2.4: local-part case is preserved.
+    #[test]
+    fn local_case_preserved() {
+        let a = EmailAddress::parse("UserName@example.com").unwrap();
+        assert_eq!(a.local().as_str(), "UserName");
+    }
+
+    /// RFC 5322 §3.4.1: all allowed atext characters accepted.
+    #[test]
+    fn parse_atext_chars() {
+        EmailAddress::parse("user+filter@example.com").unwrap();
+        EmailAddress::parse("user.name@example.com").unwrap();
+        EmailAddress::parse("user_name@example.com").unwrap();
+        EmailAddress::parse("user-name@example.com").unwrap();
+    }
+
+    /// Angle-bracket form is stripped.
+    #[test]
+    fn parse_angle_bracket_form() {
+        let a = EmailAddress::parse("<user@example.com>").unwrap();
+        assert_eq!(a.local().as_str(), "user");
+        assert_eq!(a.domain().as_str(), "example.com");
+    }
+
+    /// Whitespace around address is stripped.
+    #[test]
+    fn parse_whitespace_stripped() {
+        let a = EmailAddress::parse("  user@example.com  ").unwrap();
+        assert_eq!(a.local().as_str(), "user");
+    }
+
+    /// RFC 5322 §3.4.1: missing `@` is rejected.
+    #[test]
+    fn reject_missing_at() {
+        assert!(EmailAddress::parse("userexample.com").is_err());
+    }
+
+    /// RFC 5322 §3.4.1: adjacent dots in dot-atom rejected.
+    #[test]
+    fn reject_adjacent_dots() {
+        assert!(EmailAddress::parse("us..er@example.com").is_err());
+    }
+
+    /// RFC 5322 §3.4.1: leading dot in local part rejected.
+    #[test]
+    fn reject_leading_dot() {
+        assert!(EmailAddress::parse(".user@example.com").is_err());
+    }
+
+    /// RFC 5322 §3.4.1: trailing dot in local part rejected.
+    #[test]
+    fn reject_trailing_dot() {
+        assert!(EmailAddress::parse("user.@example.com").is_err());
+    }
+
+    /// Empty local part is rejected.
+    #[test]
+    fn reject_empty_local() {
+        assert!(EmailAddress::parse("@example.com").is_err());
+    }
+
+    /// Display renders as `local@domain`.
+    #[test]
+    fn display() {
+        let a = EmailAddress::parse("user@example.com").unwrap();
+        assert_eq!(a.to_string(), "user@example.com");
+    }
+}
+
+#[cfg(test)]
+mod rfc5321_domain {
+    use super::*;
+
+    /// RFC 5321 §2.3.5 + RFC 1123 §2.1: basic domain parse.
+    #[test]
+    fn parse_simple() {
+        let d = Domain::parse("example.com").unwrap();
+        assert_eq!(d.as_str(), "example.com");
+    }
+
+    /// RFC 5321 §2.3.5: domain normalised to lowercase.
+    #[test]
+    fn parse_uppercase_lowercased() {
+        let d = Domain::parse("EXAMPLE.COM").unwrap();
+        assert_eq!(d.as_str(), "example.com");
+    }
+
+    /// RFC 5321 §2.3.5: domain address case insensitivity applies to email.
+    #[test]
+    fn email_domain_lowercased() {
+        let a = EmailAddress::parse("user@EXAMPLE.COM").unwrap();
+        assert_eq!(a.domain().as_str(), "example.com");
+    }
+
+    /// RFC 1123 §2.1: label may start with digit (relaxation of RFC 952).
+    #[test]
+    fn label_starts_with_digit() {
+        Domain::parse("3com.example.com").unwrap();
+    }
+
+    /// Single-label domain accepted (e.g. `localhost`).
+    #[test]
+    fn single_label() {
+        let d = Domain::parse("localhost").unwrap();
+        assert_eq!(d.as_str(), "localhost");
+    }
+
+    /// RFC 1123 §2.1: label must be ≤ 63 chars.
+    #[test]
+    fn reject_label_too_long() {
+        let long_label = "a".repeat(64);
+        assert!(Domain::parse(&format!("{}.com", long_label)).is_err());
+    }
+
+    /// RFC 1123 §2.1: label cannot start with hyphen.
+    #[test]
+    fn reject_hyphen_start() {
+        assert!(Domain::parse("-bad.example.com").is_err());
+    }
+
+    /// RFC 1123 §2.1: label cannot end with hyphen.
+    #[test]
+    fn reject_hyphen_end() {
+        assert!(Domain::parse("bad-.example.com").is_err());
+    }
+
+    /// Trailing dot is rejected (we store without trailing dot for DNS construction).
+    #[test]
+    fn reject_trailing_dot() {
+        assert!(Domain::parse("example.com.").is_err());
+    }
+
+    /// Empty string is rejected.
+    #[test]
+    fn reject_empty() {
+        assert!(Domain::parse("").is_err());
+    }
+
+    /// Empty label from consecutive dots is rejected.
+    #[test]
+    fn reject_empty_label() {
+        assert!(Domain::parse("example..com").is_err());
+    }
+
+    /// RFC 6376 §3.6.2.1: dkim_txt_name constructs correct DNS query name.
+    #[test]
+    fn dkim_txt_name() {
+        let d = Domain::parse("example.com").unwrap();
+        assert_eq!(
+            d.dkim_txt_name("selector"),
+            "selector._domainkey.example.com"
+        );
+    }
+
+    /// RFC 6376 §6.1.1 step 8: exact match is parent of itself.
+    #[test]
+    fn is_parent_of_self() {
+        let d = Domain::parse("example.com").unwrap();
+        assert!(d.is_parent_of(&d.clone()));
+    }
+
+    /// RFC 6376 §6.1.1 step 8: parent of a subdomain.
+    #[test]
+    fn is_parent_of_sub() {
+        let parent = Domain::parse("example.com").unwrap();
+        let child = Domain::parse("sub.example.com").unwrap();
+        assert!(parent.is_parent_of(&child));
+    }
+
+    /// RFC 6376 §6.1.1 step 8: unrelated domain is not a parent.
+    #[test]
+    fn not_parent_of_unrelated() {
+        let d1 = Domain::parse("example.com").unwrap();
+        let d2 = Domain::parse("notexample.com").unwrap();
+        assert!(!d1.is_parent_of(&d2));
+    }
+
+    /// RFC 6376 §6.1.1 step 8: suffix match must be at a label boundary.
+    ///
+    /// "ample.com" must NOT be a parent of "example.com".
+    #[test]
+    fn not_parent_of_partial_label() {
+        let partial = Domain::parse("ample.com").unwrap();
+        let full = Domain::parse("example.com").unwrap();
+        assert!(!partial.is_parent_of(&full));
     }
 }

--- a/crates/email-primitives/src/header.rs
+++ b/crates/email-primitives/src/header.rs
@@ -47,8 +47,18 @@ pub struct HeaderName(pub(crate) String);
 impl HeaderName {
     /// Construct a header name, validating that it contains only printable
     /// ASCII characters other than `:` (RFC 5322 section 2.2 `ftext`).
-    pub fn new(_name: impl Into<String>) -> Result<Self> {
-        todo!("validate: chars in 33..=126 and char != ':'")
+    pub fn new(name: impl Into<String>) -> Result<Self> {
+        let s: String = name.into();
+        if s.is_empty() {
+            return Err(Error::InvalidHeaderName(s));
+        }
+        for b in s.bytes() {
+            // RFC 5322 §2.2: ftext = %d33-126, excluding ':'
+            if !(33..=126).contains(&b) || b == b':' {
+                return Err(Error::InvalidHeaderName(s));
+            }
+        }
+        Ok(HeaderName(s))
     }
 
     /// The field name in its original casing.
@@ -103,8 +113,30 @@ impl HeaderValue {
     ///
     /// The value must not contain bare CR or LF outside of CRLF-WSP folding
     /// sequences (RFC 5322 section 2.2).
-    pub fn new(_value: impl Into<String>) -> Result<Self> {
-        todo!("validate: no bare CR/LF; only CRLF followed by WSP is allowed")
+    pub fn new(value: impl Into<String>) -> Result<Self> {
+        let s: String = value.into();
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\r' => {
+                    // RFC 5322 §2.2: CR must be followed by LF then WSP (fold).
+                    let ok = i + 2 < bytes.len()
+                        && bytes[i + 1] == b'\n'
+                        && (bytes[i + 2] == b' ' || bytes[i + 2] == b'\t');
+                    if !ok {
+                        return Err(Error::InvalidHeaderValue(s));
+                    }
+                    i += 3;
+                }
+                b'\n' => {
+                    // Bare LF is never valid in a header value.
+                    return Err(Error::InvalidHeaderValue(s));
+                }
+                _ => i += 1,
+            }
+        }
+        Ok(HeaderValue(s))
     }
 
     /// The value with original folding preserved.
@@ -118,7 +150,9 @@ impl HeaderValue {
     /// The result is a single logical line with all inter-line whitespace
     /// collapsed to single spaces.
     pub fn unfold(&self) -> String {
-        todo!("remove CRLF WSP sequences; collapse to single WSP")
+        // RFC 5322 §2.2.3: "remove any CRLF that is immediately followed by WSP".
+        // Removing "\r\n" leaves the WSP character in place, which is correct.
+        self.0.replace("\r\n ", " ").replace("\r\n\t", "\t")
     }
 }
 
@@ -154,8 +188,32 @@ impl Header {
     ///
     /// The input should include the terminating CRLF of the final line but
     /// must NOT include the blank line that separates headers from the body.
-    pub fn parse(_input: &[u8]) -> Result<Self> {
-        todo!("winnow parser: field-name \":\" unstructured CRLF *(WSP unstructured CRLF)")
+    pub fn parse(input: &[u8]) -> Result<Self> {
+        // Find the first ':' to split name from value.
+        let colon =
+            input
+                .iter()
+                .position(|&b| b == b':')
+                .ok_or_else(|| Error::MalformedMessage {
+                    reason: "header field has no ':' separator".to_owned(),
+                })?;
+
+        let name_bytes = &input[..colon];
+        let name_str = std::str::from_utf8(name_bytes).map_err(|_| Error::MalformedMessage {
+            reason: "non-UTF-8 header field name".to_owned(),
+        })?;
+        let name = HeaderName::new(name_str)?;
+
+        // Value is everything after ':' up to (but not including) the final CRLF.
+        let value_bytes = &input[colon + 1..];
+        let value_str = std::str::from_utf8(value_bytes).map_err(|_| Error::MalformedMessage {
+            reason: "non-UTF-8 header field value".to_owned(),
+        })?;
+        // Strip exactly the trailing CRLF (folds inside are preserved).
+        let value_str = value_str.strip_suffix("\r\n").unwrap_or(value_str);
+        let value = HeaderValue::new(value_str)?;
+
+        Ok(Header { name, value })
     }
 
     /// Render the header to its wire form: `{name}:{value}\r\n`.
@@ -226,8 +284,27 @@ impl Headers {
     ///
     /// Returns [`Error::MalformedMessage`] if the header section is
     /// syntactically invalid.
-    pub fn parse(_input: &[u8]) -> Result<(Self, &[u8])> {
-        todo!("parse header fields until CRLF CRLF; return remaining bytes as body")
+    pub fn parse(input: &[u8]) -> Result<(Self, &[u8])> {
+        let mut headers = Headers::new();
+        let mut pos = 0;
+
+        loop {
+            // Blank line (CRLF with nothing before it) marks end of headers.
+            if input[pos..].starts_with(b"\r\n") {
+                return Ok((headers, &input[pos + 2..]));
+            }
+            if pos >= input.len() {
+                return Err(Error::MalformedMessage {
+                    reason: "header section not terminated by blank line".to_owned(),
+                });
+            }
+
+            let header_start = pos;
+            let header_end = find_header_end(input, pos)?;
+            let header = Header::parse(&input[header_start..header_end])?;
+            headers.push(header);
+            pos = header_end;
+        }
     }
 
     /// Return the number of header fields.
@@ -238,5 +315,249 @@ impl Headers {
     /// Return `true` if there are no header fields.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+}
+
+/// Find the byte index of the end of the current header field (including the
+/// terminating CRLF), scanning forward from `start`.
+///
+/// Continuation lines (lines beginning with WSP after a CRLF) are included
+/// in the returned range per RFC 5322 §2.2.3 folding rules.
+fn find_header_end(input: &[u8], start: usize) -> Result<usize> {
+    let mut pos = start;
+    loop {
+        // Locate the next CRLF.
+        let crlf = input[pos..]
+            .windows(2)
+            .position(|w| w == b"\r\n")
+            .ok_or_else(|| Error::MalformedMessage {
+                reason: "header field not terminated with CRLF".to_owned(),
+            })?;
+        pos += crlf + 2; // advance past the CRLF
+
+        // If the next byte is WSP this is a fold; include the continuation.
+        match input.get(pos) {
+            Some(&b' ') | Some(&b'\t') => continue,
+            _ => return Ok(pos),
+        }
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_header_name {
+    use super::*;
+
+    /// RFC 5322 §2.2: valid ftext characters (33-126 except ':').
+    #[test]
+    fn valid_names() {
+        HeaderName::new("Subject").unwrap();
+        HeaderName::new("DKIM-Signature").unwrap();
+        HeaderName::new("X-Custom-Header").unwrap();
+        HeaderName::new("From").unwrap();
+    }
+
+    /// RFC 5322 §2.2: colon is not allowed in field name.
+    #[test]
+    fn reject_colon() {
+        assert!(HeaderName::new("Sub:ject").is_err());
+    }
+
+    /// RFC 5322 §2.2: space (char 32) is below the ftext floor.
+    #[test]
+    fn reject_space() {
+        assert!(HeaderName::new("Sub ject").is_err());
+    }
+
+    /// RFC 5322 §2.2: DEL (char 127) is above the ftext ceiling.
+    #[test]
+    fn reject_del() {
+        assert!(HeaderName::new("Sub\x7fject").is_err());
+    }
+
+    /// RFC 5322 §2.2: empty string is not a valid field name.
+    #[test]
+    fn reject_empty() {
+        assert!(HeaderName::new("").is_err());
+    }
+
+    /// RFC 5322 §2.2: field names are case-insensitive.
+    #[test]
+    fn case_insensitive_eq() {
+        let a = HeaderName::new("Subject").unwrap();
+        let b = HeaderName::new("SUBJECT").unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// RFC 6376 §3.4.2: to_lowercase() for relaxed canonicalization.
+    #[test]
+    fn to_lowercase() {
+        let n = HeaderName::new("DKIM-Signature").unwrap();
+        assert_eq!(n.to_lowercase(), "dkim-signature");
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_header_value {
+    use super::*;
+
+    /// RFC 5322 §2.2: a simple ASCII value is accepted.
+    #[test]
+    fn valid_simple() {
+        HeaderValue::new(" Hello, world!").unwrap();
+    }
+
+    /// RFC 5322 §2.2.3: CRLF followed by SP is a valid fold.
+    #[test]
+    fn valid_fold_sp() {
+        HeaderValue::new(" value\r\n continued").unwrap();
+    }
+
+    /// RFC 5322 §2.2.3: CRLF followed by HTAB is a valid fold.
+    #[test]
+    fn valid_fold_htab() {
+        HeaderValue::new(" value\r\n\tcontinued").unwrap();
+    }
+
+    /// RFC 5322 §2.2: bare CR is not allowed.
+    #[test]
+    fn reject_bare_cr() {
+        assert!(HeaderValue::new(" val\rue").is_err());
+    }
+
+    /// RFC 5322 §2.2: bare LF is not allowed.
+    #[test]
+    fn reject_bare_lf() {
+        assert!(HeaderValue::new(" val\nue").is_err());
+    }
+
+    /// RFC 5322 §2.2: CRLF not followed by WSP is rejected.
+    #[test]
+    fn reject_crlf_without_wsp() {
+        assert!(HeaderValue::new(" val\r\nue").is_err());
+    }
+
+    /// RFC 5322 §2.2.3: unfold removes CRLF before SP, keeping the SP.
+    #[test]
+    fn unfold_sp() {
+        let v = HeaderValue::new(" value\r\n continued").unwrap();
+        assert_eq!(v.unfold(), " value continued");
+    }
+
+    /// RFC 5322 §2.2.3: unfold removes CRLF before HTAB, keeping the HTAB.
+    #[test]
+    fn unfold_htab() {
+        let v = HeaderValue::new(" value\r\n\tcontinued").unwrap();
+        assert_eq!(v.unfold(), " value\tcontinued");
+    }
+
+    /// RFC 5322 §2.2.3: multiple folds are all removed.
+    #[test]
+    fn unfold_multiple() {
+        let v = HeaderValue::new(" a\r\n b\r\n c").unwrap();
+        assert_eq!(v.unfold(), " a b c");
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_header_parse {
+    use super::*;
+
+    /// RFC 5322 §2.2: parse a simple non-folded header field.
+    #[test]
+    fn parse_simple() {
+        let h = Header::parse(b"Subject: Hello\r\n").unwrap();
+        assert_eq!(h.name.as_str(), "Subject");
+        assert_eq!(h.value.as_str(), " Hello");
+    }
+
+    /// RFC 5322 §2.2.3: parse a folded header field preserving the fold.
+    #[test]
+    fn parse_folded() {
+        let h = Header::parse(b"Subject: Hello\r\n world\r\n").unwrap();
+        assert_eq!(h.name.as_str(), "Subject");
+        assert!(h.value.as_str().contains("\r\n"));
+        assert_eq!(h.value.unfold(), " Hello world");
+    }
+
+    /// RFC 5322 §2.2: wire round-trip restores the original bytes.
+    #[test]
+    fn wire_round_trip() {
+        let original = "Subject: Hello\r\n";
+        let h = Header::parse(original.as_bytes()).unwrap();
+        assert_eq!(h.to_wire(), original);
+    }
+
+    /// RFC 5322 §2.2: leading space after colon is part of value.
+    #[test]
+    fn leading_space_in_value() {
+        let h = Header::parse(b"From: alice@example.com\r\n").unwrap();
+        assert_eq!(h.value.as_str(), " alice@example.com");
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_headers_parse {
+    use super::*;
+
+    /// RFC 5322 §2.1: headers section terminated by blank line (CRLF CRLF).
+    #[test]
+    fn parse_basic() {
+        let input = b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nBody here";
+        let (headers, body) = Headers::parse(input).unwrap();
+        assert_eq!(headers.len(), 2);
+        assert_eq!(body, b"Body here");
+    }
+
+    /// RFC 5322 §2.1: empty header section (blank line only) is valid.
+    #[test]
+    fn parse_empty_headers() {
+        let input = b"\r\nBody";
+        let (headers, body) = Headers::parse(input).unwrap();
+        assert_eq!(headers.len(), 0);
+        assert_eq!(body, b"Body");
+    }
+
+    /// RFC 5322 §2.2.3: folded header is parsed as a single field.
+    #[test]
+    fn parse_folded_header() {
+        let input = b"Subject: Hello\r\n world\r\n\r\n";
+        let (headers, _) = Headers::parse(input).unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers.iter().next().unwrap().name.as_str(), "Subject");
+    }
+
+    /// RFC 6376 §5.4.2: insertion order is preserved (top to bottom).
+    #[test]
+    fn insertion_order_preserved() {
+        let input = b"From: a\r\nReceived: x\r\nReceived: y\r\n\r\n";
+        let (headers, _) = Headers::parse(input).unwrap();
+        let name = HeaderName::new("Received").unwrap();
+        let received: Vec<_> = headers.get_all(&name).map(|h| h.value.as_str()).collect();
+        assert_eq!(received, [" x", " y"]);
+    }
+
+    /// RFC 6376 §5.4.2: get_last returns the bottommost occurrence.
+    #[test]
+    fn get_last_bottommost() {
+        let input = b"From: first\r\nFrom: second\r\n\r\n";
+        let (headers, _) = Headers::parse(input).unwrap();
+        let name = HeaderName::new("From").unwrap();
+        let last = headers.get_last(&name).unwrap();
+        assert_eq!(last.value.as_str(), " second");
+    }
+
+    /// RFC 5322 §2.1: missing blank-line terminator is an error.
+    #[test]
+    fn reject_missing_terminator() {
+        let result = Headers::parse(b"From: alice@example.com\r\n");
+        assert!(result.is_err());
+    }
+
+    /// Body bytes after the blank line are returned unmodified.
+    #[test]
+    fn body_returned_correctly() {
+        let input = b"From: a\r\n\r\nHello\r\nWorld\r\n";
+        let (_, body) = Headers::parse(input).unwrap();
+        assert_eq!(body, b"Hello\r\nWorld\r\n");
     }
 }

--- a/crates/email-primitives/src/message.rs
+++ b/crates/email-primitives/src/message.rs
@@ -61,8 +61,27 @@ impl Message {
     ///
     /// Returns an error if the header section is malformed, or if the
     /// header/body separator is absent.
-    pub fn parse(_input: Bytes) -> Result<Self> {
-        todo!("split at first CRLF CRLF; parse Headers; wrap remainder as MessageBody")
+    pub fn parse(input: Bytes) -> Result<Self> {
+        // RFC 5322 §2.1: the first blank line (CRLF CRLF) separates headers
+        // from the body. windows(4) finds it; we pass everything up to and
+        // including that separator to Headers::parse.
+        let sep = input
+            .windows(4)
+            .position(|w| w == b"\r\n\r\n")
+            .ok_or_else(|| crate::Error::MalformedMessage {
+                reason: "missing header/body separator (CRLF CRLF)".to_owned(),
+            })?;
+
+        // Headers::parse expects the blank line as its terminator.
+        let (headers, leftover) = Headers::parse(&input[..sep + 4])?;
+        debug_assert!(leftover.is_empty(), "Headers::parse left unexpected bytes");
+
+        // Body is everything after CRLF CRLF — zero-copy slice of the input.
+        let body = input.slice(sep + 4..);
+        Ok(Message {
+            headers,
+            body: MessageBody::new(body),
+        })
     }
 
     /// Serialise the message back to wire-format bytes.
@@ -70,12 +89,25 @@ impl Message {
     /// Output is `<headers section>\r\n<body>` where the headers section
     /// already contains the per-field terminating CRLFs.
     pub fn to_bytes(&self) -> Bytes {
-        todo!("concatenate header wire forms + CRLF + body bytes")
+        let mut buf = Vec::with_capacity(self.wire_len());
+        for header in self.headers.iter() {
+            buf.extend_from_slice(header.to_wire().as_bytes());
+        }
+        buf.extend_from_slice(b"\r\n"); // blank line separator
+        buf.extend_from_slice(self.body.as_bytes());
+        Bytes::from(buf)
     }
 
     /// Return the total length of the message in bytes (wire representation).
     pub fn wire_len(&self) -> usize {
-        todo!()
+        // Allocation-free: name + ':' + value + CRLF for each header,
+        // plus 2 bytes for the blank-line separator, plus body length.
+        self.headers
+            .iter()
+            .map(|h| h.name.as_str().len() + 1 + h.value.as_str().len() + 2)
+            .sum::<usize>()
+            + 2
+            + self.body.len()
     }
 }
 
@@ -123,5 +155,78 @@ impl MessageBody {
     /// True if the body is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod rfc5322_message {
+    use super::*;
+
+    fn simple_bytes() -> Bytes {
+        Bytes::from_static(
+            b"From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Test\r\n\r\nHello body\r\n",
+        )
+    }
+
+    /// RFC 5322 §2.1: parse splits headers and body at the first CRLF CRLF.
+    #[test]
+    fn parse_splits_correctly() {
+        let msg = Message::parse(simple_bytes()).unwrap();
+        assert_eq!(msg.headers.len(), 3);
+        assert_eq!(msg.body.as_bytes(), b"Hello body\r\n");
+    }
+
+    /// RFC 5322 §3.5: an empty body is valid.
+    #[test]
+    fn parse_empty_body() {
+        let input = Bytes::from_static(b"From: a@b.com\r\n\r\n");
+        let msg = Message::parse(input).unwrap();
+        assert_eq!(msg.headers.len(), 1);
+        assert!(msg.body.is_empty());
+    }
+
+    /// RFC 5322 §2.1: body may itself contain CRLF CRLF; only the first
+    /// occurrence separates headers from body.
+    #[test]
+    fn crlf_in_body_not_confused_with_separator() {
+        let input = Bytes::from_static(b"From: a@b.com\r\n\r\nPara 1\r\n\r\nPara 2\r\n");
+        let msg = Message::parse(input).unwrap();
+        assert_eq!(msg.body.as_bytes(), b"Para 1\r\n\r\nPara 2\r\n");
+    }
+
+    /// Round-trip: parse → to_bytes must reproduce the original bytes exactly.
+    #[test]
+    fn round_trip() {
+        let original = simple_bytes();
+        let msg = Message::parse(original.clone()).unwrap();
+        let serialised = msg.to_bytes();
+        assert_eq!(serialised, original);
+    }
+
+    /// wire_len must equal the length of to_bytes().
+    #[test]
+    fn wire_len_matches_to_bytes() {
+        let msg = Message::parse(simple_bytes()).unwrap();
+        assert_eq!(msg.wire_len(), msg.to_bytes().len());
+    }
+
+    /// RFC 5322 §2.1: missing CRLF CRLF separator is an error.
+    #[test]
+    fn reject_no_separator() {
+        let input = Bytes::from_static(b"From: a@b.com\r\nNo separator here");
+        assert!(Message::parse(input).is_err());
+    }
+
+    /// Body bytes are a zero-copy slice of the input Bytes.
+    #[test]
+    fn body_is_zero_copy_slice() {
+        let original = simple_bytes();
+        let msg = Message::parse(original.clone()).unwrap();
+        // The body slice should share the same underlying allocation.
+        assert_eq!(
+            msg.body.as_bytes().as_ptr() as usize,
+            original[original.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4..].as_ptr()
+                as usize
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Implements all `todo!()` stubs in `crates/email-primitives/` — the foundational types used by every other crate
- Adds 63 unit tests across 8 RFC-cited test modules (all passing)
- Adds `cargo-nextest` as the test runner and updates CI to use it

## What's implemented

**`address.rs`**
- `Domain::parse` — RFC 1123 §2.1 label validation (1–63 chars, `[A-Za-z0-9-]`, no leading/trailing hyphen), lowercase normalisation (RFC 5321 §2.3.5)
- `Domain::is_parent_of` — label-boundary subdomain check for DKIM (RFC 6376 §6.1.1 step 8)
- `EmailAddress::parse` — RFC 5322 §3.4.1 dot-atom and quoted-string local parts, angle-bracket stripping; uses winnow combinators

**`header.rs`**
- `HeaderName::new` — ftext validation (chars 33–126 excluding `:`, RFC 5322 §2.2)
- `HeaderValue::new` — rejects bare CR/LF; permits CRLF-WSP folds only (RFC 5322 §2.2)
- `HeaderValue::unfold` — removes CRLF before WSP, keeps the WSP (RFC 5322 §2.2.3)
- `Header::parse` — byte-level parser with fold continuation support
- `Headers::parse` — blank-line terminator, insertion order preserved for bottom-up DKIM header selection (RFC 6376 §5.4.2)

**`message.rs`**
- `Message::parse` — splits at first `\r\n\r\n`, zero-copy `Bytes::slice` for body
- `Message::to_bytes` — wire serialisation
- `Message::wire_len` — allocation-free byte count

**nextest**
- `.config/nextest.toml` with `default` and `ci` profiles
- CI updated: installs nextest via `taiki-e/install-action`, runs `cargo nextest run --workspace --profile ci`
- `AGENTS.md` essential commands updated

## Test plan

- [x] `cargo nextest run -p email-primitives` — 63/63 pass
- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p email-primitives --all-targets` — clean

https://claude.ai/code/session_012DErEnd3j8np3KGEH2rJvp

---
_Generated by [Claude Code](https://claude.ai/code/session_012DErEnd3j8np3KGEH2rJvp)_