### PR TITLE
Enable pedantic clippy lints workspace-wide; annotate stubs with #[expect]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,5 +57,20 @@ clap  = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 
 [workspace.lints.rust]
-missing_docs    = "warn"
+dead_code       = "deny"
+missing_docs    = "deny"
 unreachable_pub = "warn"
+unused_imports  = "deny"
+
+[workspace.lints.clippy]
+# Lint groups (lower priority so individual overrides take effect)
+all      = { level = "deny", priority = -3 }
+pedantic = { level = "deny", priority = -2 }
+nursery  = { level = "deny", priority = -1 }
+# Selected restriction lints
+allow_attributes_without_reason = "deny"
+unwrap_used                      = "deny"
+# Project-wide allowances
+missing_panics_doc      = "allow"  # stubs use todo!() which panics; revisit once implemented
+module_name_repetitions = "allow"  # conventional for re-exported types (e.g. dkim::DkimSignature)
+wildcard_imports        = "allow"  # idiomatic in test modules (use super::*)

--- a/crates/arc/src/auth_results.rs
+++ b/crates/arc/src/auth_results.rs
@@ -79,31 +79,34 @@ pub struct AuthResultProperty {
 
 impl AuthResultsValue {
     /// Parse one method result clause from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::HeaderParse`] if the clause is malformed.
     pub fn parse(_clause: &str) -> crate::Result<Self> {
         todo!(
             "split on first '='; method name before '=', rest is result + properties; \
              extract optional 'reason=...' and 'ptype.property=value' triples"
         )
     }
+}
 
-    /// Serialise the result clause to a string.
-    pub fn to_string(&self) -> String {
-        let mut out = format!("{}={}", self.method, self.result);
+impl std::fmt::Display for AuthResultsValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}={}", self.method, self.result)?;
         if let Some(reason) = &self.reason {
-            out.push_str(&format!(" reason={reason:?}"));
+            write!(f, " reason={reason:?}")?;
         }
         for prop in &self.properties {
-            out.push_str(&format!(
-                "\n    {}.{}={}",
-                prop.ptype, prop.property, prop.value
-            ));
+            write!(f, "\n    {}.{}={}", prop.ptype, prop.property, prop.value)?;
         }
-        out
+        Ok(())
     }
 }
 
 impl AuthResultProperty {
     /// Construct a `header.d=<domain>` property (used in DKIM results).
+    #[must_use]
     pub fn header_d(domain: &email_primitives::Domain) -> Self {
         Self {
             ptype: "header".to_owned(),
@@ -113,6 +116,7 @@ impl AuthResultProperty {
     }
 
     /// Construct a `header.s=<selector>` property (used in DKIM results).
+    #[must_use]
     pub fn header_s(selector: &str) -> Self {
         Self {
             ptype: "header".to_owned(),
@@ -122,6 +126,7 @@ impl AuthResultProperty {
     }
 
     /// Construct a `header.i=<auid>` property (used in DKIM results).
+    #[must_use]
     pub fn header_i(auid: &str) -> Self {
         Self {
             ptype: "header".to_owned(),
@@ -131,6 +136,7 @@ impl AuthResultProperty {
     }
 
     /// Construct a `smtp.mailfrom=<addr>` property (used in SPF results).
+    #[must_use]
     pub fn smtp_mailfrom(addr: &str) -> Self {
         Self {
             ptype: "smtp".to_owned(),
@@ -143,6 +149,7 @@ impl AuthResultProperty {
     ///
     /// Records the oldest instance number that contributed to a `pass` result
     /// (RFC 8617 §7.1).
+    #[must_use]
     pub fn arc_oldest_pass(instance: u32) -> Self {
         Self {
             ptype: "header".to_owned(),

--- a/crates/arc/src/chain.rs
+++ b/crates/arc/src/chain.rs
@@ -9,29 +9,20 @@
 //!
 //! 2. **Group** them into [`ArcSet`]s by instance number.
 //!
-//! 3. **Check structure**:
-//!    - Instance numbers must be contiguous integers starting at 1.
-//!    - Each instance must have exactly one of each header type.
-//!    - The highest instance's `ARC-Seal` must have `cv=none` iff `i=1`,
-//!      or `cv=pass`/`cv=fail` for `i>1`.
+//! 3. **Check structure**: instance numbers must be contiguous integers
+//!    starting at 1; each instance must have exactly one of each header type;
+//!    the highest instance's ARC-Seal must have `cv=none` iff `i=1`.
 //!
 //! 4. **Verify the oldest AMS** (`i=1`): this is a DKIM signature over the
 //!    original message body and selected headers. If it fails, the chain fails.
 //!
-//! 5. **Verify each ARC-Seal** in ascending order of `i`:
-//!    - The Seal covers all ARC headers from instances 1 through `i`.
-//!    - Specifically, the hash input for AS with instance `i` is the
-//!      concatenation (bottom-up) of all:
-//!      - `ARC-Authentication-Results` from `i=1` through `i=i`
-//!      - `ARC-Message-Signature` from `i=1` through `i=i`
-//!      - `ARC-Seal` from `i=1` through `i=i-1` (not the current one)
-//!      plus the current `ARC-Seal` with `b=` empty.
-//!    - The hash input order follows RFC 8617 §5.1.1.
+//! 5. **Verify each ARC-Seal** in ascending order of `i`. The hash input for
+//!    AS with instance `i` covers all AAR and AMS headers from i=1..N, all
+//!    AS headers from i=1..N-1 (bottom-up), plus the current AS with `b=`
+//!    empty. See RFC 8617 §5.1.1.
 //!
-//! 6. **Report** the result:
-//!    - `none` if there are no ARC headers.
-//!    - `pass` if all verifications succeeded.
-//!    - `fail` if any verification failed.
+//! 6. **Report** the result: `none` if there are no ARC headers; `pass` if
+//!    all verifications succeeded; `fail` if any verification failed.
 //!
 //! # Chain result in Authentication-Results
 //!
@@ -58,7 +49,8 @@ pub enum ArcChainResult {
 
 impl ArcChainResult {
     /// The `arc=<result>` string for an `Authentication-Results` header.
-    pub fn as_str(self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Pass => "pass",
@@ -90,12 +82,14 @@ pub struct ChainValidator {
     ///
     /// ARC uses the same DNS key publication mechanism as DKIM
     /// (`<selector>._domainkey.<domain>` TXT records).
+    #[expect(dead_code, reason = "stub: used by validate() once implemented")]
     resolver: dkim::dns::DkimResolver,
 }
 
 impl ChainValidator {
     /// Construct a validator with the provided DNS resolver.
-    pub fn new(resolver: dkim::dns::DkimResolver) -> Self {
+    #[must_use]
+    pub const fn new(resolver: dkim::dns::DkimResolver) -> Self {
         Self { resolver }
     }
 
@@ -109,6 +103,10 @@ impl ChainValidator {
     /// Only structural errors (e.g. missing ARC headers in a set, non-
     /// contiguous instance numbers) are returned as `Err`. Cryptographic
     /// failures produce `ArcChainResult::Fail` inside the `Ok` value.
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await DNS calls once implemented"
+    )]
     pub async fn validate(&self, message: &Message) -> Result<ChainValidationOutput> {
         let _ = message;
         todo!(
@@ -124,6 +122,7 @@ impl ChainValidator {
     /// Collect all ARC headers from a message and group them into [`ArcSet`]s.
     ///
     /// Returns sets sorted by ascending instance number.
+    #[expect(dead_code, reason = "stub: called by validate() once implemented")]
     fn collect_arc_sets(_message: &Message) -> Result<Vec<ArcSet>> {
         todo!(
             "scan headers for ARC-Seal, ARC-Message-Signature, ARC-Authentication-Results; \
@@ -136,6 +135,11 @@ impl ChainValidator {
     ///
     /// This is a standard DKIM verification (RFC 8617 §6.1 step 3). It covers
     /// the message as it was first received by the ARC chain.
+    #[expect(dead_code, reason = "stub: called by validate() once implemented")]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await resolver once implemented"
+    )]
     async fn verify_oldest_ams(
         _set: &ArcSet,
         _message: &Message,
@@ -156,6 +160,11 @@ impl ChainValidator {
     /// - All ARC-Message-Signatures i=1 through i=N (top-down)
     /// - All ARC-Seals i=1 through i=N-1 (top-down, NOT the current seal)
     /// - The current ARC-Seal header with `b=` empty
+    #[expect(dead_code, reason = "stub: called by validate() once implemented")]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await resolver once implemented"
+    )]
     async fn verify_seal(
         _seal: &ArcSet,
         _all_sets: &[ArcSet],

--- a/crates/arc/src/headers.rs
+++ b/crates/arc/src/headers.rs
@@ -63,6 +63,10 @@ pub enum ChainValidation {
 
 impl ChainValidation {
     /// Parse the `cv=` tag value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::HeaderParse`] for unknown `cv=` values.
     pub fn parse(s: &str) -> Result<Self> {
         match s {
             "none" => Ok(Self::None),
@@ -73,7 +77,8 @@ impl ChainValidation {
     }
 
     /// The wire representation.
-    pub fn as_str(self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::None => "none",
             Self::Pass => "pass",
@@ -85,9 +90,9 @@ impl ChainValidation {
 impl From<ArcChainResult> for ChainValidation {
     fn from(r: ArcChainResult) -> Self {
         match r {
-            ArcChainResult::None => ChainValidation::None,
-            ArcChainResult::Pass => ChainValidation::Pass,
-            ArcChainResult::Fail => ChainValidation::Fail,
+            ArcChainResult::None => Self::None,
+            ArcChainResult::Pass => Self::Pass,
+            ArcChainResult::Fail => Self::Fail,
         }
     }
 }
@@ -105,6 +110,10 @@ pub struct AuthenticationResults {
 
 impl AuthenticationResults {
     /// Parse from the header field value (after the colon).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::HeaderParse`] if the value is malformed.
     pub fn parse(_value: &str) -> Result<Self> {
         todo!(
             "parse 'i=<n>;' prefix; then authserv-id; \
@@ -113,6 +122,7 @@ impl AuthenticationResults {
     }
 
     /// Serialise to a header value string (without the `ARC-Authentication-Results:` prefix).
+    #[must_use]
     pub fn to_header_value(&self) -> String {
         todo!("i=<n>; <authserv-id>; <results joined by '; '>")
     }
@@ -134,6 +144,11 @@ pub struct ArcMessageSignature {
 
 impl ArcMessageSignature {
     /// Parse from the header field value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::HeaderParse`] if `i=` is missing or invalid, or if
+    /// the embedded DKIM-Signature is malformed.
     pub fn parse(_value: &str) -> Result<Self> {
         todo!(
             "extract 'i=<n>;' prefix; pass remainder to DkimSignature::parse; \
@@ -142,6 +157,7 @@ impl ArcMessageSignature {
     }
 
     /// Serialise to a header value string.
+    #[must_use]
     pub fn to_header_value(&self) -> String {
         todo!("'i=<n>; ' + inner.to_tag_list()")
     }
@@ -168,6 +184,10 @@ pub struct ArcSeal {
 
 impl ArcSeal {
     /// Parse from the header field value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::HeaderParse`] if required tags are absent or malformed.
     pub fn parse(_value: &str) -> Result<Self> {
         todo!(
             "TagList::parse; extract i, a, cv, d, s, t, b; \
@@ -176,11 +196,13 @@ impl ArcSeal {
     }
 
     /// Serialise to a header value string (with the actual signature).
+    #[must_use]
     pub fn to_header_value(&self) -> String {
         todo!("emit all tags in canonical order; base64-encode b; fold long lines")
     }
 
     /// Serialise with `b=` empty, for use as signing input.
+    #[must_use]
     pub fn to_signing_input(&self) -> String {
         todo!("same as to_header_value but with b= empty")
     }
@@ -205,7 +227,9 @@ pub struct ArcSet {
 impl ArcSet {
     /// Validate that all three headers have the same `i=` value.
     ///
-    /// Returns an error if the instance numbers are inconsistent.
+    /// # Errors
+    ///
+    /// Returns [`Error::HeaderParse`] if the instance numbers are inconsistent.
     pub fn validate_instance_consistency(&self) -> Result<()> {
         todo!(
             "check self.auth_results.instance == self.message_signature.instance \

--- a/crates/arc/src/lib.rs
+++ b/crates/arc/src/lib.rs
@@ -70,8 +70,6 @@
 //! - [`chain`] – chain validation logic.
 //! - [`seal`] – signing: construct and add an ARC set.
 
-#![warn(missing_docs)]
-
 pub mod auth_results;
 pub mod chain;
 pub mod headers;

--- a/crates/arc/src/seal.rs
+++ b/crates/arc/src/seal.rs
@@ -56,7 +56,7 @@ use email_primitives::Message;
 use crate::Result;
 use crate::auth_results::AuthResultsValue;
 use crate::chain::ArcChainResult;
-use crate::headers::{ArcSet, AuthenticationResults};
+use crate::headers::ArcSet;
 
 /// Parameters for adding an ARC set to a message.
 #[derive(Debug)]
@@ -88,16 +88,23 @@ pub struct SealRequest {
 /// A single [`ArcSigner`] instance should be reused across messages so that
 /// the underlying key material is loaded only once.
 pub struct ArcSigner {
+    #[expect(dead_code, reason = "stub: used by seal() once implemented")]
     private_key: dkim::key::PrivateKey,
 }
 
 impl ArcSigner {
     /// Construct an [`ArcSigner`] from a private key.
-    pub fn new(key: dkim::key::PrivateKey) -> Self {
+    #[must_use]
+    pub const fn new(key: dkim::key::PrivateKey) -> Self {
         Self { private_key: key }
     }
 
     /// Load a private key from a PEM file and construct an [`ArcSigner`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Dkim`] if the PEM file cannot be read or the
+    /// key is malformed.
     pub fn from_pem_file(path: &std::path::Path) -> Result<Self> {
         let _ = path;
         todo!("dkim::key::PrivateKey::from_pem_file(path).map(Self::new)")
@@ -115,6 +122,11 @@ impl ArcSigner {
     /// The `prior_chain_result` argument should be the output of
     /// [`crate::chain::ChainValidator::validate`] called on the received
     /// message.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::InstanceLimitExceeded`] if adding a new set
+    /// would set `i > 50` (RFC 8617 §5.1.1.3).
     pub fn seal(
         &self,
         message: &Message,
@@ -145,6 +157,7 @@ impl ArcSigner {
     ///
     /// The ordering within each `i` is: AAR, then AMS; seals are appended
     /// after all AAR/AMS pairs. The new seal with empty `b=` is last.
+    #[expect(dead_code, reason = "stub: called by seal() once implemented")]
     fn build_seal_hash_input(
         _existing_sets: &[ArcSet],
         _new_aar_header: &str,

--- a/crates/dkim/src/canonicalize.rs
+++ b/crates/dkim/src/canonicalize.rs
@@ -49,7 +49,7 @@
 
 use email_primitives::{Header, Headers};
 
-use crate::signature::{Canonicalization, CanonicalizationAlgorithm};
+use crate::signature::CanonicalizationAlgorithm;
 
 /// Canonicalize a header field for inclusion in the signing hash.
 ///
@@ -60,6 +60,7 @@ use crate::signature::{Canonicalization, CanonicalizationAlgorithm};
 ///
 /// For the DKIM-Signature header itself, the value passed to this function
 /// must have `b=` set to empty (RFC 6376 §3.7 step 5).
+#[must_use]
 pub fn canonicalize_header(header: &Header, algo: CanonicalizationAlgorithm) -> Vec<u8> {
     let _ = (header, algo);
     todo!(
@@ -79,6 +80,7 @@ pub fn canonicalize_header(header: &Header, algo: CanonicalizationAlgorithm) -> 
 /// prevents an attacker from adding a header that was covered by the signature.
 ///
 /// Returns the concatenated canonical form of all selected headers.
+#[must_use]
 pub fn canonicalize_headers(
     headers: &Headers,
     signed_names: &[String],
@@ -97,6 +99,7 @@ pub fn canonicalize_headers(
 /// of the canonicalized output are hashed. If `None`, the entire body is used.
 ///
 /// Returns the canonicalized body bytes (possibly truncated to `limit`).
+#[must_use]
 pub fn canonicalize_body(
     body: &[u8],
     algo: CanonicalizationAlgorithm,
@@ -113,6 +116,7 @@ pub fn canonicalize_body(
 /// Compute the SHA-256 hash of the canonicalized body and return it as raw bytes.
 ///
 /// This is the `bh=` value (before base64 encoding).
+#[must_use]
 pub fn body_hash(canonicalized_body: &[u8]) -> [u8; 32] {
     let _ = canonicalized_body;
     todo!("ring::digest::digest(&ring::digest::SHA256, canonicalized_body)")

--- a/crates/dkim/src/dns.rs
+++ b/crates/dkim/src/dns.rs
@@ -37,8 +37,13 @@
 
 use hickory_resolver::TokioAsyncResolver;
 
+#[expect(
+    unused_imports,
+    reason = "stub: Error variants referenced when implemented"
+)]
+use crate::Error;
+use crate::Result;
 use crate::key::PublicKey;
-use crate::{Error, Result};
 
 /// A parsed DKIM DNS record.
 #[derive(Debug, Clone)]
@@ -62,7 +67,7 @@ pub struct DkimDnsRecord {
 /// Key type from the `k=` DNS tag.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyType {
-    /// `k=rsa` – RSA public key in SubjectPublicKeyInfo (SPKI) DER format,
+    /// `k=rsa` – RSA public key in `SubjectPublicKeyInfo` (SPKI) DER format,
     /// base64-encoded (RFC 6376 §3.6.1).
     Rsa,
     /// `k=ed25519` – Ed25519 public key as 32 raw bytes, base64-encoded
@@ -83,6 +88,11 @@ pub enum DnsFlag {
 
 impl DkimDnsRecord {
     /// Parse a DKIM DNS TXT record string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::TagListParse`] on syntax errors, or
+    /// [`crate::Error::DnsPermError`] if the `p=` key is empty (revoked).
     pub fn parse(_txt: &str) -> Result<Self> {
         todo!(
             "TagList::parse(txt); extract k, p, v, t; \
@@ -92,7 +102,9 @@ impl DkimDnsRecord {
 
     /// Convert the record into a usable [`PublicKey`].
     ///
-    /// Returns [`Error::DnsPermError`] if the key is revoked (empty `p=`).
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::DnsPermError`] if the key is revoked (empty `p=`).
     pub fn into_public_key(self) -> Result<PublicKey> {
         let _ = self;
         todo!("match key_type; decode DER bytes via ring; return PublicKey")
@@ -104,12 +116,21 @@ impl DkimDnsRecord {
 /// A single [`DkimResolver`] instance should be shared across the service
 /// (e.g. via `Arc`) to benefit from the internal DNS cache.
 pub struct DkimResolver {
+    #[expect(dead_code, reason = "stub: used by lookup() once implemented")]
     inner: TokioAsyncResolver,
 }
 
 impl DkimResolver {
     /// Construct a new resolver using the system's DNS configuration
     /// (`/etc/resolv.conf` on Linux).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the system resolver configuration cannot be read.
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await resolver once implemented"
+    )]
     pub async fn from_system_conf() -> Result<Self> {
         todo!("TokioAsyncResolver::from_system_conf(ResolverOpts::default())")
     }
@@ -120,10 +141,14 @@ impl DkimResolver {
     ///
     /// # Errors
     ///
-    /// - [`Error::DnsTempError`] for transient failures (SERVFAIL, timeout).
-    /// - [`Error::DnsPermError`] for NXDOMAIN or empty `p=` (revoked key).
-    /// - [`Error::KeyDecode`] if the record is present but the key bytes are
+    /// - [`crate::Error::DnsTempError`] for transient failures (SERVFAIL, timeout).
+    /// - [`crate::Error::DnsPermError`] for NXDOMAIN or empty `p=` (revoked key).
+    /// - [`crate::Error::KeyDecode`] if the record is present but the key bytes are
     ///   malformed.
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await inner.txt_lookup once implemented"
+    )]
     pub async fn lookup(
         &self,
         selector: &str,

--- a/crates/dkim/src/key.rs
+++ b/crates/dkim/src/key.rs
@@ -8,7 +8,7 @@
 //!
 //! | Algorithm | Private key format | Public key format |
 //! |-----------|-------------------|------------------|
-//! | RSA | PKCS#8 DER | SubjectPublicKeyInfo DER |
+//! | RSA | PKCS#8 DER | `SubjectPublicKeyInfo` DER |
 //! | Ed25519 | PKCS#8 DER (seed) | 32 raw bytes |
 //!
 //! Both formats are base64-encoded in the config file and DNS TXT records
@@ -22,7 +22,12 @@
 //! selector is used for fresh signatures. Retire the old selector once its
 //! TTL has elapsed and any in-transit mail has been delivered.
 
-use crate::{Error, Result};
+#[expect(
+    unused_imports,
+    reason = "stub: Error variants referenced when implemented"
+)]
+use crate::Error;
+use crate::Result;
 
 /// A DKIM private key, used for signing.
 ///
@@ -37,25 +42,38 @@ pub enum PrivateKey {
 impl std::fmt::Debug for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PrivateKey::Rsa(_) => f.write_str("PrivateKey::Rsa(...)"),
-            PrivateKey::Ed25519(_) => f.write_str("PrivateKey::Ed25519(...)"),
+            Self::Rsa(_) => f.write_str("PrivateKey::Rsa(...)"),
+            Self::Ed25519(_) => f.write_str("PrivateKey::Ed25519(...)"),
         }
     }
 }
 
 impl PrivateKey {
     /// Load an RSA private key from PKCS#8 DER bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::KeyDecode`] if the DER bytes are malformed.
     pub fn rsa_from_pkcs8_der(_der: &[u8]) -> Result<Self> {
         todo!("ring::signature::RsaKeyPair::from_pkcs8(der).map_err(...)")
     }
 
     /// Load an Ed25519 private key from PKCS#8 DER bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::KeyDecode`] if the DER bytes are malformed.
     pub fn ed25519_from_pkcs8_der(_der: &[u8]) -> Result<Self> {
         todo!("ring::signature::Ed25519KeyPair::from_pkcs8(der).map_err(...)")
     }
 
     /// Load a private key from a PEM-encoded file (auto-detects RSA vs Ed25519
     /// from the PEM type header).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::KeyDecode`] if the file cannot be read or
+    /// the key bytes are malformed.
     pub fn from_pem_file(_path: &std::path::Path) -> Result<Self> {
         todo!(
             "read PEM; strip headers; base64-decode; \
@@ -68,6 +86,10 @@ impl PrivateKey {
     ///
     /// Returns the raw signature bytes. The caller is responsible for
     /// base64-encoding the result for the `b=` tag.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Io`] if the signing operation fails.
     pub fn sign(&self, _data: &[u8]) -> Result<Vec<u8>> {
         todo!(
             "Rsa: ring::signature::RsaKeyPair::sign(&RSA_PKCS1_SHA256, rng, data, sig); \
@@ -76,10 +98,11 @@ impl PrivateKey {
     }
 
     /// The algorithm tag (`a=`) for the `DKIM-Signature` header.
-    pub fn algorithm(&self) -> crate::signature::Algorithm {
+    #[must_use]
+    pub const fn algorithm(&self) -> crate::signature::Algorithm {
         match self {
-            PrivateKey::Rsa(_) => crate::signature::Algorithm::RsaSha256,
-            PrivateKey::Ed25519(_) => crate::signature::Algorithm::Ed25519Sha256,
+            Self::Rsa(_) => crate::signature::Algorithm::RsaSha256,
+            Self::Ed25519(_) => crate::signature::Algorithm::Ed25519Sha256,
         }
     }
 }
@@ -97,8 +120,8 @@ pub enum PublicKey {
 impl std::fmt::Debug for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PublicKey::Rsa(_) => f.write_str("PublicKey::Rsa(...)"),
-            PublicKey::Ed25519(_) => f.write_str("PublicKey::Ed25519(...)"),
+            Self::Rsa(_) => f.write_str("PublicKey::Rsa(...)"),
+            Self::Ed25519(_) => f.write_str("PublicKey::Ed25519(...)"),
         }
     }
 }
@@ -106,7 +129,11 @@ impl std::fmt::Debug for PublicKey {
 impl PublicKey {
     /// Verify a signature over `data`.
     ///
-    /// Returns `Ok(())` on success, [`Error::SignatureMismatch`] on failure.
+    /// Returns `Ok(())` on success, [`crate::Error::SignatureMismatch`] on failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::SignatureMismatch`] if the signature is invalid.
     pub fn verify(&self, _data: &[u8], _signature: &[u8]) -> Result<()> {
         todo!(
             "self.inner.verify(data, signature) \

--- a/crates/dkim/src/lib.rs
+++ b/crates/dkim/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Overview
 //!
-//! DomainKeys Identified Mail (DKIM) lets a domain take responsibility for a
+//! `DomainKeys` Identified Mail (DKIM) lets a domain take responsibility for a
 //! message by attaching a cryptographic signature in a `DKIM-Signature` header
 //! field. Receiving MTAs (and milters) verify the signature by fetching the
 //! corresponding public key from DNS.
@@ -27,14 +27,9 @@
 //! # Verification algorithm (RFC 6376 §6)
 //!
 //! 1. Extract all `DKIM-Signature` headers (there may be multiple).
-//! 2. For each signature (in order):
-//!    a. Parse and validate the tag-list.
-//!    b. Fetch the public key: `<s>._domainkey.<d>` TXT record (§3.6.2).
-//!    c. Canonicalise body; verify `bh=` matches.
-//!    d. Canonicalise the signed header fields.
-//!    e. Verify the signature against the public key.
-//!    f. Record the result (`pass` / `fail` / `neutral` / `permerror` /
-//!       `temperror`).
+//! 2. For each signature (in order): parse the tag-list; fetch the public key
+//!    from DNS; canonicalise the body and check `bh=`; canonicalise the signed
+//!    headers; verify the signature; record the result.
 //! 3. Return the best result across all signatures.
 //!
 //! # Supported algorithms
@@ -73,8 +68,6 @@
 //! - [`key`]          – key types wrapping `ring` primitives.
 //! - [`sign`]         – signing a message with a private key.
 //! - [`verify`]       – verifying `DKIM-Signature` headers.
-
-#![warn(missing_docs)]
 
 pub mod canonicalize;
 pub mod dns;

--- a/crates/dkim/src/sign.rs
+++ b/crates/dkim/src/sign.rs
@@ -41,7 +41,12 @@ use email_primitives::{Domain, Message};
 
 use crate::Result;
 use crate::key::PrivateKey;
-use crate::signature::{Canonicalization, DkimSignature};
+use crate::signature::Canonicalization;
+#[expect(
+    unused_imports,
+    reason = "stub: DkimSignature used when sign() is implemented"
+)]
+use crate::signature::DkimSignature;
 
 /// Parameters for a DKIM signing operation.
 #[derive(Debug)]
@@ -75,6 +80,7 @@ impl SignRequest {
     ///
     /// Default header list covers the fields recommended by RFC 6376 §5.4.1
     /// plus "over-signing" of `From:` and `To:`.
+    #[must_use]
     pub fn new(domain: Domain, selector: impl Into<String>) -> Self {
         Self {
             domain,
@@ -106,13 +112,16 @@ impl SignRequest {
 /// Create one [`Signer`] per domain/selector/key combination. The signer is
 /// cheaply cloneable and safe to share across threads (`Arc<Signer>`).
 pub struct Signer {
+    #[expect(dead_code, reason = "stub: used by sign() once implemented")]
     private_key: PrivateKey,
+    #[expect(dead_code, reason = "stub: used by sign() once implemented")]
     default_request: SignRequest,
 }
 
 impl Signer {
     /// Construct a signer.
-    pub fn new(key: PrivateKey, default_request: SignRequest) -> Self {
+    #[must_use]
+    pub const fn new(key: PrivateKey, default_request: SignRequest) -> Self {
         Self {
             private_key: key,
             default_request,
@@ -141,6 +150,11 @@ impl Signer {
     }
 
     /// Sign a message with a custom [`SignRequest`], overriding the default.
+    ///
+    /// # Errors
+    ///
+    /// - If the message has no `From:` header.
+    /// - If the private key signing operation fails.
     pub fn sign_with(&self, message: &Message, request: &SignRequest) -> Result<Message> {
         let _ = (message, request);
         todo!("same as sign() but using `request` instead of `self.default_request`")

--- a/crates/dkim/src/signature.rs
+++ b/crates/dkim/src/signature.rs
@@ -28,7 +28,12 @@
 
 use email_primitives::Domain;
 
-use crate::{Error, Result, tag_list::TagList};
+#[expect(
+    unused_imports,
+    reason = "stub: TagList used when parse() is implemented"
+)]
+use crate::tag_list::TagList;
+use crate::{Error, Result};
 
 /// The signing algorithm used in `a=`.
 ///
@@ -49,10 +54,14 @@ pub enum Algorithm {
 
 impl Algorithm {
     /// Parse the algorithm tag value string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidTag`] for unknown or deprecated algorithms.
     pub fn parse(s: &str) -> Result<Self> {
         match s {
-            "rsa-sha256" => Ok(Algorithm::RsaSha256),
-            "ed25519-sha256" => Ok(Algorithm::Ed25519Sha256),
+            "rsa-sha256" => Ok(Self::RsaSha256),
+            "ed25519-sha256" => Ok(Self::Ed25519Sha256),
             "rsa-sha1" => Err(Error::InvalidTag {
                 tag: "a",
                 reason: "rsa-sha1 is deprecated and MUST NOT be used (RFC 8301)".to_owned(),
@@ -65,10 +74,11 @@ impl Algorithm {
     }
 
     /// The wire representation for the `a=` tag.
-    pub fn as_str(self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
         match self {
-            Algorithm::RsaSha256 => "rsa-sha256",
-            Algorithm::Ed25519Sha256 => "ed25519-sha256",
+            Self::RsaSha256 => "rsa-sha256",
+            Self::Ed25519Sha256 => "ed25519-sha256",
         }
     }
 }
@@ -86,6 +96,10 @@ pub enum CanonicalizationAlgorithm {
 
 impl CanonicalizationAlgorithm {
     /// Parse `"simple"` or `"relaxed"`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidTag`] for unknown algorithm names.
     pub fn parse(s: &str) -> Result<Self> {
         match s {
             "simple" => Ok(Self::Simple),
@@ -98,7 +112,8 @@ impl CanonicalizationAlgorithm {
     }
 
     /// The wire representation.
-    pub fn as_str(self) -> &'static str {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Simple => "simple",
             Self::Relaxed => "relaxed",
@@ -119,7 +134,7 @@ pub struct Canonicalization {
 
 impl Canonicalization {
     /// `relaxed/relaxed` – the most common production choice.
-    pub const RELAXED_RELAXED: Canonicalization = Canonicalization {
+    pub const RELAXED_RELAXED: Self = Self {
         header: CanonicalizationAlgorithm::Relaxed,
         body: CanonicalizationAlgorithm::Relaxed,
     };
@@ -128,12 +143,17 @@ impl Canonicalization {
     ///
     /// If the body algorithm is absent, it defaults to `simple`
     /// (RFC 6376 §3.5 `c=` tag description).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidTag`] if either algorithm name is unknown.
     pub fn parse(s: &str) -> Result<Self> {
         let _ = s;
         todo!("split on '/'; parse each half; default body to simple if absent")
     }
 
     /// Serialise to `<header>/<body>`.
+    #[must_use]
     pub fn as_str(self) -> String {
         format!("{}/{}", self.header.as_str(), self.body.as_str())
     }
@@ -194,6 +214,11 @@ impl DkimSignature {
     ///
     /// Validates that all required tags (`v`, `a`, `b`, `bh`, `d`, `h`, `s`)
     /// are present and that `v=1`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MissingTag`] for absent required tags, or
+    /// [`Error::InvalidTag`] for malformed values.
     pub fn parse(_value: &str) -> Result<Self> {
         todo!(
             "TagList::parse(value); extract required tags; \
@@ -208,6 +233,7 @@ impl DkimSignature {
     /// The `b=` tag is included with the actual signature value. Use
     /// [`DkimSignature::to_signing_input`] to obtain the hash input (with `b=`
     /// empty).
+    #[must_use]
     pub fn to_tag_list(&self) -> String {
         todo!("emit all tags in canonical order; base64-encode b and bh; fold long lines")
     }
@@ -216,6 +242,7 @@ impl DkimSignature {
     ///
     /// This is the tag-list with `b=` set to empty, as specified in
     /// RFC 6376 §3.7 step 5.
+    #[must_use]
     pub fn to_signing_input(&self) -> String {
         todo!("same as to_tag_list but with b= empty")
     }

--- a/crates/dkim/src/tag_list.rs
+++ b/crates/dkim/src/tag_list.rs
@@ -24,9 +24,18 @@
 //!   an empty value, and the byte positions of other tags are fixed by their
 //!   original order in the header.
 
+#[expect(
+    unused_imports,
+    reason = "stub: HashMap used in parse() for duplicate detection"
+)]
 use std::collections::HashMap;
 
-use crate::{Error, Result};
+#[expect(
+    unused_imports,
+    reason = "stub: Error variants referenced when parse() is implemented"
+)]
+use crate::Error;
+use crate::Result;
 
 /// A parsed tag-value list.
 ///
@@ -43,8 +52,8 @@ impl TagList {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::TagListParse`] on syntax errors.
-    /// Returns [`Error::InvalidTag`] with `tag = "duplicate"` if a tag name
+    /// Returns [`crate::Error::TagListParse`] on syntax errors.
+    /// Returns [`crate::Error::InvalidTag`] with `tag = "duplicate"` if a tag name
     /// appears more than once (RFC 6376 §3.2 rule 5).
     pub fn parse(_input: &str) -> Result<Self> {
         todo!(
@@ -57,6 +66,7 @@ impl TagList {
     ///
     /// The name comparison is case-sensitive (tag names are case-sensitive per
     /// RFC 6376 §3.2, unlike header field names).
+    #[must_use]
     pub fn get(&self, name: &str) -> Option<&str> {
         self.ordered
             .iter()
@@ -72,6 +82,7 @@ impl TagList {
     /// Serialise to `tag=value; tag=value` form.
     ///
     /// Tags are emitted in insertion order. No trailing semicolon is added.
+    #[must_use]
     pub fn to_string_compact(&self) -> String {
         self.ordered
             .iter()
@@ -83,6 +94,7 @@ impl TagList {
     /// Return a version of the serialised form with `b=` set to the empty
     /// string, as required when computing the hash input for the DKIM-Signature
     /// header (RFC 6376 §3.7 step 5).
+    #[must_use]
     pub fn with_empty_b(&self) -> String {
         self.ordered
             .iter()

--- a/crates/dkim/src/verify.rs
+++ b/crates/dkim/src/verify.rs
@@ -35,7 +35,15 @@
 use email_primitives::Message;
 
 use crate::dns::DkimResolver;
+#[expect(
+    unused_imports,
+    reason = "stub: DkimSignature used when verify() is implemented"
+)]
 use crate::signature::DkimSignature;
+#[expect(
+    unused_imports,
+    reason = "stub: Error and Result used when verify() is implemented"
+)]
 use crate::{Error, Result};
 
 /// The outcome of verifying a single `DKIM-Signature`.
@@ -81,7 +89,8 @@ pub struct VerificationResult {
 
 impl VerificationResult {
     /// Construct a `none` result (no DKIM-Signature present).
-    pub fn none() -> Self {
+    #[must_use]
+    pub const fn none() -> Self {
         Self {
             status: VerificationStatus::None,
             domain: None,
@@ -97,6 +106,7 @@ impl VerificationResult {
     /// ```text
     /// dkim=pass header.d=example.com header.s=selector header.i=@example.com
     /// ```
+    #[must_use]
     pub fn to_auth_results_value(&self) -> String {
         todo!(
             "format 'dkim=<status>'; \
@@ -110,12 +120,14 @@ impl VerificationResult {
 
 /// Verifies `DKIM-Signature` headers in a message.
 pub struct Verifier {
+    #[expect(dead_code, reason = "stub: used by verify() once implemented")]
     resolver: DkimResolver,
 }
 
 impl Verifier {
     /// Construct a verifier using the provided DNS resolver.
-    pub fn new(resolver: DkimResolver) -> Self {
+    #[must_use]
+    pub const fn new(resolver: DkimResolver) -> Self {
         Self { resolver }
     }
 
@@ -126,6 +138,10 @@ impl Verifier {
     ///
     /// If the message contains no `DKIM-Signature` headers, returns a
     /// single-element vec containing [`VerificationResult::none()`].
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await DNS resolver once implemented"
+    )]
     pub async fn verify(&self, message: &Message) -> Vec<VerificationResult> {
         let _ = message;
         todo!(
@@ -143,6 +159,7 @@ impl Verifier {
     ///
     /// Preference: `pass` > `neutral` > `fail` > `permerror` > `temperror`
     /// > `none`.
+    #[must_use]
     pub fn best_result(results: &[VerificationResult]) -> &VerificationResult {
         let _ = results;
         todo!("iterate and pick highest-precedence status")

--- a/crates/email-primitives/src/address.rs
+++ b/crates/email-primitives/src/address.rs
@@ -81,21 +81,24 @@ impl EmailAddress {
         let domain =
             Domain::parse(domain_str).map_err(|_| Error::InvalidAddress(input.to_owned()))?;
 
-        Ok(EmailAddress { local, domain })
+        Ok(Self { local, domain })
     }
 
     /// The local part (the portion to the left of `@`).
-    pub fn local(&self) -> &LocalPart {
+    #[must_use]
+    pub const fn local(&self) -> &LocalPart {
         &self.local
     }
 
     /// The domain (the portion to the right of `@`), normalised to lowercase.
-    pub fn domain(&self) -> &Domain {
+    #[must_use]
+    pub const fn domain(&self) -> &Domain {
         &self.domain
     }
 
     /// Borrow as a [`ReversePath`] for use in SMTP/LMTP `MAIL FROM`.
-    pub fn as_reverse_path(&self) -> ReversePath<'_> {
+    #[must_use]
+    pub const fn as_reverse_path(&self) -> ReversePath<'_> {
         ReversePath::Address(self)
     }
 }
@@ -107,7 +110,7 @@ impl std::fmt::Display for EmailAddress {
 }
 
 /// Returns true if `c` is an `atext` character per RFC 5322 §3.2.3.
-fn is_atext(c: char) -> bool {
+const fn is_atext(c: char) -> bool {
     matches!(
         c,
         'A'..='Z'
@@ -200,6 +203,7 @@ pub struct LocalPart(pub(crate) String);
 
 impl LocalPart {
     /// The raw string value, preserving original quoting.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -247,12 +251,13 @@ impl Domain {
             return Err(Error::InvalidDomain(input.to_owned()));
         }
         for label in input.split('.') {
-            validate_label(label).map_err(|_| Error::InvalidDomain(input.to_owned()))?;
+            validate_label(label).map_err(|()| Error::InvalidDomain(input.to_owned()))?;
         }
-        Ok(Domain(input.to_ascii_lowercase()))
+        Ok(Self(input.to_ascii_lowercase()))
     }
 
     /// The domain as a lowercase ASCII string, suitable for DNS queries.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -260,6 +265,7 @@ impl Domain {
     /// Construct the DKIM DNS query name for a given selector.
     ///
     /// Returns `<selector>._domainkey.<domain>` per RFC 6376 section 3.6.2.1.
+    #[must_use]
     pub fn dkim_txt_name(&self, selector: &str) -> String {
         format!("{}._domainkey.{}", selector, self.0)
     }
@@ -274,7 +280,8 @@ impl Domain {
     /// - `"example.com".is_parent_of("example.com")` → `true`
     /// - `"example.com".is_parent_of("sub.example.com")` → `true`
     /// - `"example.com".is_parent_of("other.com")` → `false`
-    pub fn is_parent_of(&self, other: &Domain) -> bool {
+    #[must_use]
+    pub fn is_parent_of(&self, other: &Self) -> bool {
         // Both are already lowercase, so direct comparison is correct.
         // The ".{self}" suffix check ensures we match at a label boundary,
         // preventing "ample.com" from being a parent of "example.com".
@@ -312,7 +319,7 @@ impl TryFrom<&str> for Domain {
     type Error = Error;
 
     fn try_from(s: &str) -> Result<Self> {
-        Domain::parse(s)
+        Self::parse(s)
     }
 }
 
@@ -332,8 +339,8 @@ pub enum ReversePath<'a> {
 impl std::fmt::Display for ReversePath<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ReversePath::Address(addr) => write!(f, "<{addr}>"),
-            ReversePath::Null => f.write_str("<>"),
+            Self::Address(addr) => write!(f, "<{addr}>"),
+            Self::Null => f.write_str("<>"),
         }
     }
 }
@@ -350,8 +357,8 @@ pub enum NullPath {
 impl std::fmt::Display for NullPath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            NullPath::Address(addr) => write!(f, "<{addr}>"),
-            NullPath::Null => f.write_str("<>"),
+            Self::Address(addr) => write!(f, "<{addr}>"),
+            Self::Null => f.write_str("<>"),
         }
     }
 }
@@ -363,7 +370,7 @@ mod rfc5322_address {
     /// RFC 5322 §3.4.1: basic dot-atom addr-spec.
     #[test]
     fn parse_simple() {
-        let a = EmailAddress::parse("user@example.com").unwrap();
+        let a = EmailAddress::parse("user@example.com").expect("valid addr-spec");
         assert_eq!(a.local().as_str(), "user");
         assert_eq!(a.domain().as_str(), "example.com");
     }
@@ -371,7 +378,8 @@ mod rfc5322_address {
     /// RFC 5322 §3.4.1: quoted-string local part.
     #[test]
     fn parse_quoted_local() {
-        let a = EmailAddress::parse("\"user name\"@example.com").unwrap();
+        let a =
+            EmailAddress::parse("\"user name\"@example.com").expect("valid quoted-string local");
         assert_eq!(a.local().as_str(), "\"user name\"");
         assert_eq!(a.domain().as_str(), "example.com");
     }
@@ -379,30 +387,31 @@ mod rfc5322_address {
     /// RFC 5322 §3.4.1: quoted-pair inside quoted local part.
     #[test]
     fn parse_quoted_pair_local() {
-        let a = EmailAddress::parse("\"user\\\"quoted\"@example.com").unwrap();
+        let a =
+            EmailAddress::parse("\"user\\\"quoted\"@example.com").expect("valid quoted-pair local");
         assert!(a.local().as_str().starts_with('"'));
     }
 
     /// RFC 5321 §2.4: local-part case is preserved.
     #[test]
     fn local_case_preserved() {
-        let a = EmailAddress::parse("UserName@example.com").unwrap();
+        let a = EmailAddress::parse("UserName@example.com").expect("valid addr-spec");
         assert_eq!(a.local().as_str(), "UserName");
     }
 
     /// RFC 5322 §3.4.1: all allowed atext characters accepted.
     #[test]
     fn parse_atext_chars() {
-        EmailAddress::parse("user+filter@example.com").unwrap();
-        EmailAddress::parse("user.name@example.com").unwrap();
-        EmailAddress::parse("user_name@example.com").unwrap();
-        EmailAddress::parse("user-name@example.com").unwrap();
+        EmailAddress::parse("user+filter@example.com").expect("+ is atext");
+        EmailAddress::parse("user.name@example.com").expect(". in local is atext");
+        EmailAddress::parse("user_name@example.com").expect("_ is atext");
+        EmailAddress::parse("user-name@example.com").expect("- is atext");
     }
 
     /// Angle-bracket form is stripped.
     #[test]
     fn parse_angle_bracket_form() {
-        let a = EmailAddress::parse("<user@example.com>").unwrap();
+        let a = EmailAddress::parse("<user@example.com>").expect("angle-bracket form");
         assert_eq!(a.local().as_str(), "user");
         assert_eq!(a.domain().as_str(), "example.com");
     }
@@ -410,7 +419,7 @@ mod rfc5322_address {
     /// Whitespace around address is stripped.
     #[test]
     fn parse_whitespace_stripped() {
-        let a = EmailAddress::parse("  user@example.com  ").unwrap();
+        let a = EmailAddress::parse("  user@example.com  ").expect("whitespace-padded addr");
         assert_eq!(a.local().as_str(), "user");
     }
 
@@ -447,7 +456,7 @@ mod rfc5322_address {
     /// Display renders as `local@domain`.
     #[test]
     fn display() {
-        let a = EmailAddress::parse("user@example.com").unwrap();
+        let a = EmailAddress::parse("user@example.com").expect("valid addr-spec");
         assert_eq!(a.to_string(), "user@example.com");
     }
 }
@@ -459,34 +468,34 @@ mod rfc5321_domain {
     /// RFC 5321 §2.3.5 + RFC 1123 §2.1: basic domain parse.
     #[test]
     fn parse_simple() {
-        let d = Domain::parse("example.com").unwrap();
+        let d = Domain::parse("example.com").expect("valid domain");
         assert_eq!(d.as_str(), "example.com");
     }
 
     /// RFC 5321 §2.3.5: domain normalised to lowercase.
     #[test]
     fn parse_uppercase_lowercased() {
-        let d = Domain::parse("EXAMPLE.COM").unwrap();
+        let d = Domain::parse("EXAMPLE.COM").expect("valid domain");
         assert_eq!(d.as_str(), "example.com");
     }
 
     /// RFC 5321 §2.3.5: domain address case insensitivity applies to email.
     #[test]
     fn email_domain_lowercased() {
-        let a = EmailAddress::parse("user@EXAMPLE.COM").unwrap();
+        let a = EmailAddress::parse("user@EXAMPLE.COM").expect("valid addr-spec");
         assert_eq!(a.domain().as_str(), "example.com");
     }
 
     /// RFC 1123 §2.1: label may start with digit (relaxation of RFC 952).
     #[test]
     fn label_starts_with_digit() {
-        Domain::parse("3com.example.com").unwrap();
+        Domain::parse("3com.example.com").expect("digit-leading label is valid");
     }
 
     /// Single-label domain accepted (e.g. `localhost`).
     #[test]
     fn single_label() {
-        let d = Domain::parse("localhost").unwrap();
+        let d = Domain::parse("localhost").expect("single-label domain");
         assert_eq!(d.as_str(), "localhost");
     }
 
@@ -494,7 +503,7 @@ mod rfc5321_domain {
     #[test]
     fn reject_label_too_long() {
         let long_label = "a".repeat(64);
-        assert!(Domain::parse(&format!("{}.com", long_label)).is_err());
+        assert!(Domain::parse(&format!("{long_label}.com")).is_err());
     }
 
     /// RFC 1123 §2.1: label cannot start with hyphen.
@@ -527,10 +536,10 @@ mod rfc5321_domain {
         assert!(Domain::parse("example..com").is_err());
     }
 
-    /// RFC 6376 §3.6.2.1: dkim_txt_name constructs correct DNS query name.
+    /// RFC 6376 §3.6.2.1: `dkim_txt_name` constructs correct DNS query name.
     #[test]
     fn dkim_txt_name() {
-        let d = Domain::parse("example.com").unwrap();
+        let d = Domain::parse("example.com").expect("valid domain");
         assert_eq!(
             d.dkim_txt_name("selector"),
             "selector._domainkey.example.com"
@@ -540,33 +549,33 @@ mod rfc5321_domain {
     /// RFC 6376 §6.1.1 step 8: exact match is parent of itself.
     #[test]
     fn is_parent_of_self() {
-        let d = Domain::parse("example.com").unwrap();
+        let d = Domain::parse("example.com").expect("valid domain");
         assert!(d.is_parent_of(&d.clone()));
     }
 
     /// RFC 6376 §6.1.1 step 8: parent of a subdomain.
     #[test]
     fn is_parent_of_sub() {
-        let parent = Domain::parse("example.com").unwrap();
-        let child = Domain::parse("sub.example.com").unwrap();
+        let parent = Domain::parse("example.com").expect("valid domain");
+        let child = Domain::parse("sub.example.com").expect("valid domain");
         assert!(parent.is_parent_of(&child));
     }
 
     /// RFC 6376 §6.1.1 step 8: unrelated domain is not a parent.
     #[test]
     fn not_parent_of_unrelated() {
-        let d1 = Domain::parse("example.com").unwrap();
-        let d2 = Domain::parse("notexample.com").unwrap();
+        let d1 = Domain::parse("example.com").expect("valid domain");
+        let d2 = Domain::parse("notexample.com").expect("valid domain");
         assert!(!d1.is_parent_of(&d2));
     }
 
     /// RFC 6376 §6.1.1 step 8: suffix match must be at a label boundary.
     ///
-    /// "ample.com" must NOT be a parent of "example.com".
+    /// `"ample.com"` must NOT be a parent of `"example.com"`.
     #[test]
     fn not_parent_of_partial_label() {
-        let partial = Domain::parse("ample.com").unwrap();
-        let full = Domain::parse("example.com").unwrap();
+        let partial = Domain::parse("ample.com").expect("valid domain");
+        let full = Domain::parse("example.com").expect("valid domain");
         assert!(!partial.is_parent_of(&full));
     }
 }

--- a/crates/email-primitives/src/header.rs
+++ b/crates/email-primitives/src/header.rs
@@ -12,9 +12,9 @@
 //!
 //! # Folding and unfolding
 //!
-//! Long header values may be "folded" across multiple lines. A fold is a CRLF
+//! Long header values may be "folded" across multiple lines. A fold is a `CRLF`
 //! followed by at least one WSP (SP or HTAB) character. Unfolding reverses
-//! this by removing the CRLF before each WSP (RFC 5322 section 2.2.3).
+//! this by removing the `CRLF` before each WSP (RFC 5322 section 2.2.3).
 //!
 //! DKIM and ARC both work on **unfolded** header values when canonicalising,
 //! then re-add their own folding in the generated signature headers.
@@ -47,6 +47,11 @@ pub struct HeaderName(pub(crate) String);
 impl HeaderName {
     /// Construct a header name, validating that it contains only printable
     /// ASCII characters other than `:` (RFC 5322 section 2.2 `ftext`).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidHeaderName`] if the name is empty, contains
+    /// characters outside printable US-ASCII (33–126), or contains a colon.
     pub fn new(name: impl Into<String>) -> Result<Self> {
         let s: String = name.into();
         if s.is_empty() {
@@ -58,16 +63,18 @@ impl HeaderName {
                 return Err(Error::InvalidHeaderName(s));
             }
         }
-        Ok(HeaderName(s))
+        Ok(Self(s))
     }
 
     /// The field name in its original casing.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
     /// The field name lowercased, for case-insensitive comparisons and DKIM
     /// relaxed canonicalization.
+    #[must_use]
     pub fn to_lowercase(&self) -> String {
         self.0.to_ascii_lowercase()
     }
@@ -95,7 +102,7 @@ impl std::fmt::Display for HeaderName {
 
 /// The value portion of a header field.
 ///
-/// Stored with its original folding intact (CRLF WSP sequences). Use
+/// Stored with its original folding intact (`CRLF` WSP sequences). Use
 /// [`HeaderValue::unfold`] to obtain a single logical line. The leading space
 /// after the colon is included in the stored value to preserve round-trip
 /// fidelity.
@@ -103,7 +110,7 @@ impl std::fmt::Display for HeaderName {
 /// # DKIM note
 ///
 /// When DKIM signs or verifies a header, the full `name: value` line (with
-/// trailing CRLF but **without** the terminating CRLF of the DKIM-Signature
+/// trailing `CRLF` but **without** the terminating `CRLF` of the DKIM-Signature
 /// itself) is included in the hash input. See RFC 6376 section 3.4.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeaderValue(pub(crate) String);
@@ -111,8 +118,13 @@ pub struct HeaderValue(pub(crate) String);
 impl HeaderValue {
     /// Construct a header value from a raw string.
     ///
-    /// The value must not contain bare CR or LF outside of CRLF-WSP folding
+    /// The value must not contain bare CR or LF outside of `CRLF`-WSP folding
     /// sequences (RFC 5322 section 2.2).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidHeaderValue`] if the value contains bare CR or
+    /// LF outside of `CRLF`-WSP folding sequences.
     pub fn new(value: impl Into<String>) -> Result<Self> {
         let s: String = value.into();
         let bytes = s.as_bytes();
@@ -136,19 +148,21 @@ impl HeaderValue {
                 _ => i += 1,
             }
         }
-        Ok(HeaderValue(s))
+        Ok(Self(s))
     }
 
     /// The value with original folding preserved.
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }
 
-    /// Unfold the value by removing CRLF sequences that are followed by WSP
+    /// Unfold the value by removing `CRLF` sequences that are followed by WSP
     /// (RFC 5322 section 2.2.3).
     ///
     /// The result is a single logical line with all inter-line whitespace
     /// collapsed to single spaces.
+    #[must_use]
     pub fn unfold(&self) -> String {
         // RFC 5322 §2.2.3: "remove any CRLF that is immediately followed by WSP".
         // Removing "\r\n" leaves the WSP character in place, which is correct.
@@ -179,15 +193,22 @@ pub struct Header {
 
 impl Header {
     /// Construct a header from a name and value.
-    pub fn new(name: HeaderName, value: HeaderValue) -> Self {
+    #[must_use]
+    pub const fn new(name: HeaderName, value: HeaderValue) -> Self {
         Self { name, value }
     }
 
     /// Parse a single header field line (or folded multiline header) from a
     /// byte slice.
     ///
-    /// The input should include the terminating CRLF of the final line but
+    /// The input should include the terminating `CRLF` of the final line but
     /// must NOT include the blank line that separates headers from the body.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::MalformedMessage`] if the input has no `:` separator or
+    /// contains non-UTF-8 bytes. Returns [`Error::InvalidHeaderName`] or
+    /// [`Error::InvalidHeaderValue`] for structurally invalid fields.
     pub fn parse(input: &[u8]) -> Result<Self> {
         // Find the first ':' to split name from value.
         let colon =
@@ -213,12 +234,13 @@ impl Header {
         let value_str = value_str.strip_suffix("\r\n").unwrap_or(value_str);
         let value = HeaderValue::new(value_str)?;
 
-        Ok(Header { name, value })
+        Ok(Self { name, value })
     }
 
     /// Render the header to its wire form: `{name}:{value}\r\n`.
     ///
-    /// Consumers should not add an extra CRLF; the trailing CRLF is included.
+    /// Consumers should not add an extra `CRLF`; the trailing `CRLF` is included.
+    #[must_use]
     pub fn to_wire(&self) -> String {
         format!("{}:{}\r\n", self.name, self.value)
     }
@@ -245,6 +267,7 @@ pub struct Headers(Vec<Header>);
 
 impl Headers {
     /// Construct an empty header list.
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -270,6 +293,7 @@ impl Headers {
     ///
     /// "Last" means the bottommost occurrence in the header section, which is
     /// the canonical value for most singular header fields.
+    #[must_use]
     pub fn get_last(&self, name: &HeaderName) -> Option<&Header> {
         self.0.iter().rev().find(|h| &h.name == name)
     }
@@ -285,7 +309,7 @@ impl Headers {
     /// Returns [`Error::MalformedMessage`] if the header section is
     /// syntactically invalid.
     pub fn parse(input: &[u8]) -> Result<(Self, &[u8])> {
-        let mut headers = Headers::new();
+        let mut headers = Self::new();
         let mut pos = 0;
 
         loop {
@@ -308,20 +332,22 @@ impl Headers {
     }
 
     /// Return the number of header fields.
-    pub fn len(&self) -> usize {
+    #[must_use]
+    pub const fn len(&self) -> usize {
         self.0.len()
     }
 
     /// Return `true` if there are no header fields.
-    pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
 
 /// Find the byte index of the end of the current header field (including the
-/// terminating CRLF), scanning forward from `start`.
+/// terminating `CRLF`), scanning forward from `start`.
 ///
-/// Continuation lines (lines beginning with WSP after a CRLF) are included
+/// Continuation lines (lines beginning with WSP after a `CRLF`) are included
 /// in the returned range per RFC 5322 §2.2.3 folding rules.
 fn find_header_end(input: &[u8], start: usize) -> Result<usize> {
     let mut pos = start;
@@ -337,7 +363,7 @@ fn find_header_end(input: &[u8], start: usize) -> Result<usize> {
 
         // If the next byte is WSP this is a fold; include the continuation.
         match input.get(pos) {
-            Some(&b' ') | Some(&b'\t') => continue,
+            Some(&b' ' | &b'\t') => {}
             _ => return Ok(pos),
         }
     }
@@ -350,10 +376,10 @@ mod rfc5322_header_name {
     /// RFC 5322 §2.2: valid ftext characters (33-126 except ':').
     #[test]
     fn valid_names() {
-        HeaderName::new("Subject").unwrap();
-        HeaderName::new("DKIM-Signature").unwrap();
-        HeaderName::new("X-Custom-Header").unwrap();
-        HeaderName::new("From").unwrap();
+        HeaderName::new("Subject").expect("Subject is a valid header name");
+        HeaderName::new("DKIM-Signature").expect("DKIM-Signature is a valid header name");
+        HeaderName::new("X-Custom-Header").expect("X-Custom-Header is a valid header name");
+        HeaderName::new("From").expect("From is a valid header name");
     }
 
     /// RFC 5322 §2.2: colon is not allowed in field name.
@@ -383,15 +409,15 @@ mod rfc5322_header_name {
     /// RFC 5322 §2.2: field names are case-insensitive.
     #[test]
     fn case_insensitive_eq() {
-        let a = HeaderName::new("Subject").unwrap();
-        let b = HeaderName::new("SUBJECT").unwrap();
+        let a = HeaderName::new("Subject").expect("valid header name");
+        let b = HeaderName::new("SUBJECT").expect("valid header name");
         assert_eq!(a, b);
     }
 
-    /// RFC 6376 §3.4.2: to_lowercase() for relaxed canonicalization.
+    /// RFC 6376 §3.4.2: `to_lowercase()` for relaxed canonicalization.
     #[test]
     fn to_lowercase() {
-        let n = HeaderName::new("DKIM-Signature").unwrap();
+        let n = HeaderName::new("DKIM-Signature").expect("valid header name");
         assert_eq!(n.to_lowercase(), "dkim-signature");
     }
 }
@@ -403,19 +429,19 @@ mod rfc5322_header_value {
     /// RFC 5322 §2.2: a simple ASCII value is accepted.
     #[test]
     fn valid_simple() {
-        HeaderValue::new(" Hello, world!").unwrap();
+        HeaderValue::new(" Hello, world!").expect("simple ASCII value");
     }
 
-    /// RFC 5322 §2.2.3: CRLF followed by SP is a valid fold.
+    /// RFC 5322 §2.2.3: `CRLF` followed by SP is a valid fold.
     #[test]
     fn valid_fold_sp() {
-        HeaderValue::new(" value\r\n continued").unwrap();
+        HeaderValue::new(" value\r\n continued").expect("CRLF+SP fold");
     }
 
-    /// RFC 5322 §2.2.3: CRLF followed by HTAB is a valid fold.
+    /// RFC 5322 §2.2.3: `CRLF` followed by HTAB is a valid fold.
     #[test]
     fn valid_fold_htab() {
-        HeaderValue::new(" value\r\n\tcontinued").unwrap();
+        HeaderValue::new(" value\r\n\tcontinued").expect("CRLF+HTAB fold");
     }
 
     /// RFC 5322 §2.2: bare CR is not allowed.
@@ -430,30 +456,30 @@ mod rfc5322_header_value {
         assert!(HeaderValue::new(" val\nue").is_err());
     }
 
-    /// RFC 5322 §2.2: CRLF not followed by WSP is rejected.
+    /// RFC 5322 §2.2: `CRLF` not followed by WSP is rejected.
     #[test]
     fn reject_crlf_without_wsp() {
         assert!(HeaderValue::new(" val\r\nue").is_err());
     }
 
-    /// RFC 5322 §2.2.3: unfold removes CRLF before SP, keeping the SP.
+    /// RFC 5322 §2.2.3: unfold removes `CRLF` before SP, keeping the SP.
     #[test]
     fn unfold_sp() {
-        let v = HeaderValue::new(" value\r\n continued").unwrap();
+        let v = HeaderValue::new(" value\r\n continued").expect("CRLF+SP fold");
         assert_eq!(v.unfold(), " value continued");
     }
 
-    /// RFC 5322 §2.2.3: unfold removes CRLF before HTAB, keeping the HTAB.
+    /// RFC 5322 §2.2.3: unfold removes `CRLF` before HTAB, keeping the HTAB.
     #[test]
     fn unfold_htab() {
-        let v = HeaderValue::new(" value\r\n\tcontinued").unwrap();
+        let v = HeaderValue::new(" value\r\n\tcontinued").expect("CRLF+HTAB fold");
         assert_eq!(v.unfold(), " value\tcontinued");
     }
 
     /// RFC 5322 §2.2.3: multiple folds are all removed.
     #[test]
     fn unfold_multiple() {
-        let v = HeaderValue::new(" a\r\n b\r\n c").unwrap();
+        let v = HeaderValue::new(" a\r\n b\r\n c").expect("multiple folds");
         assert_eq!(v.unfold(), " a b c");
     }
 }
@@ -465,7 +491,7 @@ mod rfc5322_header_parse {
     /// RFC 5322 §2.2: parse a simple non-folded header field.
     #[test]
     fn parse_simple() {
-        let h = Header::parse(b"Subject: Hello\r\n").unwrap();
+        let h = Header::parse(b"Subject: Hello\r\n").expect("simple header");
         assert_eq!(h.name.as_str(), "Subject");
         assert_eq!(h.value.as_str(), " Hello");
     }
@@ -473,7 +499,7 @@ mod rfc5322_header_parse {
     /// RFC 5322 §2.2.3: parse a folded header field preserving the fold.
     #[test]
     fn parse_folded() {
-        let h = Header::parse(b"Subject: Hello\r\n world\r\n").unwrap();
+        let h = Header::parse(b"Subject: Hello\r\n world\r\n").expect("folded header");
         assert_eq!(h.name.as_str(), "Subject");
         assert!(h.value.as_str().contains("\r\n"));
         assert_eq!(h.value.unfold(), " Hello world");
@@ -483,14 +509,14 @@ mod rfc5322_header_parse {
     #[test]
     fn wire_round_trip() {
         let original = "Subject: Hello\r\n";
-        let h = Header::parse(original.as_bytes()).unwrap();
+        let h = Header::parse(original.as_bytes()).expect("valid header");
         assert_eq!(h.to_wire(), original);
     }
 
     /// RFC 5322 §2.2: leading space after colon is part of value.
     #[test]
     fn leading_space_in_value() {
-        let h = Header::parse(b"From: alice@example.com\r\n").unwrap();
+        let h = Header::parse(b"From: alice@example.com\r\n").expect("From header");
         assert_eq!(h.value.as_str(), " alice@example.com");
     }
 }
@@ -499,11 +525,11 @@ mod rfc5322_header_parse {
 mod rfc5322_headers_parse {
     use super::*;
 
-    /// RFC 5322 §2.1: headers section terminated by blank line (CRLF CRLF).
+    /// RFC 5322 §2.1: headers section terminated by blank line (`CRLF CRLF`).
     #[test]
     fn parse_basic() {
         let input = b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nBody here";
-        let (headers, body) = Headers::parse(input).unwrap();
+        let (headers, body) = Headers::parse(input).expect("basic headers");
         assert_eq!(headers.len(), 2);
         assert_eq!(body, b"Body here");
     }
@@ -512,7 +538,7 @@ mod rfc5322_headers_parse {
     #[test]
     fn parse_empty_headers() {
         let input = b"\r\nBody";
-        let (headers, body) = Headers::parse(input).unwrap();
+        let (headers, body) = Headers::parse(input).expect("empty header section");
         assert_eq!(headers.len(), 0);
         assert_eq!(body, b"Body");
     }
@@ -521,28 +547,31 @@ mod rfc5322_headers_parse {
     #[test]
     fn parse_folded_header() {
         let input = b"Subject: Hello\r\n world\r\n\r\n";
-        let (headers, _) = Headers::parse(input).unwrap();
+        let (headers, _) = Headers::parse(input).expect("folded header section");
         assert_eq!(headers.len(), 1);
-        assert_eq!(headers.iter().next().unwrap().name.as_str(), "Subject");
+        assert_eq!(
+            headers.iter().next().expect("one header").name.as_str(),
+            "Subject"
+        );
     }
 
     /// RFC 6376 §5.4.2: insertion order is preserved (top to bottom).
     #[test]
     fn insertion_order_preserved() {
         let input = b"From: a\r\nReceived: x\r\nReceived: y\r\n\r\n";
-        let (headers, _) = Headers::parse(input).unwrap();
-        let name = HeaderName::new("Received").unwrap();
+        let (headers, _) = Headers::parse(input).expect("headers with duplicates");
+        let name = HeaderName::new("Received").expect("valid header name");
         let received: Vec<_> = headers.get_all(&name).map(|h| h.value.as_str()).collect();
         assert_eq!(received, [" x", " y"]);
     }
 
-    /// RFC 6376 §5.4.2: get_last returns the bottommost occurrence.
+    /// RFC 6376 §5.4.2: `get_last` returns the bottommost occurrence.
     #[test]
     fn get_last_bottommost() {
         let input = b"From: first\r\nFrom: second\r\n\r\n";
-        let (headers, _) = Headers::parse(input).unwrap();
-        let name = HeaderName::new("From").unwrap();
-        let last = headers.get_last(&name).unwrap();
+        let (headers, _) = Headers::parse(input).expect("duplicate From headers");
+        let name = HeaderName::new("From").expect("valid header name");
+        let last = headers.get_last(&name).expect("at least one From header");
         assert_eq!(last.value.as_str(), " second");
     }
 
@@ -557,7 +586,7 @@ mod rfc5322_headers_parse {
     #[test]
     fn body_returned_correctly() {
         let input = b"From: a\r\n\r\nHello\r\nWorld\r\n";
-        let (_, body) = Headers::parse(input).unwrap();
+        let (_, body) = Headers::parse(input).expect("valid headers");
         assert_eq!(body, b"Hello\r\nWorld\r\n");
     }
 }

--- a/crates/email-primitives/src/lib.rs
+++ b/crates/email-primitives/src/lib.rs
@@ -43,8 +43,6 @@
 //! - [`header`]  – header field types, folding/unfolding, ordered collections
 //! - [`message`] – top-level [`Message`] type combining headers and body
 
-#![warn(missing_docs)]
-
 pub mod address;
 pub mod error;
 pub mod header;

--- a/crates/email-primitives/src/message.rs
+++ b/crates/email-primitives/src/message.rs
@@ -10,7 +10,7 @@
 //! ```
 //!
 //! The header section and body are separated by exactly one blank line (a
-//! bare CRLF). The body may contain arbitrary octets subject to line-length
+//! bare `CRLF`). The body may contain arbitrary octets subject to line-length
 //! limits, but in the context of DKIM/ARC signing, the body hash is computed
 //! over the canonical body (RFC 6376 section 3.4).
 //!
@@ -31,7 +31,7 @@ use crate::{Headers, Result};
 
 /// A complete email message: header section plus body.
 ///
-/// The message is stored in its wire form with CRLF line endings throughout.
+/// The message is stored in its wire form with `CRLF` line endings throughout.
 /// Headers are parsed into the [`Headers`] structure; the body is kept as raw
 /// bytes to avoid unnecessary copies and to preserve exact byte content for
 /// hashing.
@@ -39,7 +39,7 @@ use crate::{Headers, Result};
 pub struct Message {
     /// The parsed header fields in original wire order.
     pub headers: Headers,
-    /// The raw message body with CRLF line endings.
+    /// The raw message body with `CRLF` line endings.
     ///
     /// Does not include the header/body separator blank line. The body may be
     /// empty (RFC 5322 section 3.5 permits messages with no body).
@@ -48,7 +48,8 @@ pub struct Message {
 
 impl Message {
     /// Construct a [`Message`] from pre-parsed components.
-    pub fn new(headers: Headers, body: MessageBody) -> Self {
+    #[must_use]
+    pub const fn new(headers: Headers, body: MessageBody) -> Self {
         Self { headers, body }
     }
 
@@ -61,7 +62,7 @@ impl Message {
     ///
     /// Returns an error if the header section is malformed, or if the
     /// header/body separator is absent.
-    pub fn parse(input: Bytes) -> Result<Self> {
+    pub fn parse(input: &Bytes) -> Result<Self> {
         // RFC 5322 §2.1: the first blank line (CRLF CRLF) separates headers
         // from the body. windows(4) finds it; we pass everything up to and
         // including that separator to Headers::parse.
@@ -78,7 +79,7 @@ impl Message {
 
         // Body is everything after CRLF CRLF — zero-copy slice of the input.
         let body = input.slice(sep + 4..);
-        Ok(Message {
+        Ok(Self {
             headers,
             body: MessageBody::new(body),
         })
@@ -87,7 +88,8 @@ impl Message {
     /// Serialise the message back to wire-format bytes.
     ///
     /// Output is `<headers section>\r\n<body>` where the headers section
-    /// already contains the per-field terminating CRLFs.
+    /// already contains the per-field terminating `CRLF`s.
+    #[must_use]
     pub fn to_bytes(&self) -> Bytes {
         let mut buf = Vec::with_capacity(self.wire_len());
         for header in self.headers.iter() {
@@ -99,6 +101,7 @@ impl Message {
     }
 
     /// Return the total length of the message in bytes (wire representation).
+    #[must_use]
     pub fn wire_len(&self) -> usize {
         // Allocation-free: name + ':' + value + CRLF for each header,
         // plus 2 bytes for the blank-line separator, plus body length.
@@ -119,12 +122,12 @@ impl Message {
 /// algorithms apply to the body:
 ///
 /// - **simple** (RFC 6376 section 3.4.3): the body is unchanged except that
-///   all trailing CRLF sequences are removed, then a single CRLF is appended.
-///   An empty body is canonicalised to a single CRLF.
+///   all trailing `CRLF` sequences are removed, then a single `CRLF` is appended.
+///   An empty body is canonicalised to a single `CRLF`.
 ///
 /// - **relaxed** (RFC 6376 section 3.4.4): runs of whitespace within each
 ///   line are compressed to a single SP; trailing whitespace is removed from
-///   each line; trailing empty lines are removed; a single CRLF is appended.
+///   each line; trailing empty lines are removed; a single `CRLF` is appended.
 ///
 /// The `l=` tag in DKIM-Signature allows signing only a prefix of the body
 /// (by byte count of the **canonicalised** body). This is not recommended
@@ -136,24 +139,28 @@ pub struct MessageBody(pub(crate) Bytes);
 impl MessageBody {
     /// Construct a body from raw bytes.
     ///
-    /// The bytes must use CRLF line endings. No validation is performed here;
+    /// The bytes must use `CRLF` line endings. No validation is performed here;
     /// malformed line endings will produce incorrect DKIM body hashes.
-    pub fn new(bytes: Bytes) -> Self {
+    #[must_use]
+    pub const fn new(bytes: Bytes) -> Self {
         Self(bytes)
     }
 
     /// The raw bytes of the body.
+    #[must_use]
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
     /// The length of the body in bytes.
-    pub fn len(&self) -> usize {
+    #[must_use]
+    pub const fn len(&self) -> usize {
         self.0.len()
     }
 
     /// True if the body is empty.
-    pub fn is_empty(&self) -> bool {
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }
@@ -168,10 +175,10 @@ mod rfc5322_message {
         )
     }
 
-    /// RFC 5322 §2.1: parse splits headers and body at the first CRLF CRLF.
+    /// RFC 5322 §2.1: parse splits headers and body at the first `\r\n\r\n`.
     #[test]
     fn parse_splits_correctly() {
-        let msg = Message::parse(simple_bytes()).unwrap();
+        let msg = Message::parse(&simple_bytes()).expect("valid message");
         assert_eq!(msg.headers.len(), 3);
         assert_eq!(msg.body.as_bytes(), b"Hello body\r\n");
     }
@@ -180,53 +187,57 @@ mod rfc5322_message {
     #[test]
     fn parse_empty_body() {
         let input = Bytes::from_static(b"From: a@b.com\r\n\r\n");
-        let msg = Message::parse(input).unwrap();
+        let msg = Message::parse(&input).expect("message with empty body");
         assert_eq!(msg.headers.len(), 1);
         assert!(msg.body.is_empty());
     }
 
-    /// RFC 5322 §2.1: body may itself contain CRLF CRLF; only the first
+    /// RFC 5322 §2.1: body may itself contain `\r\n\r\n`; only the first
     /// occurrence separates headers from body.
     #[test]
     fn crlf_in_body_not_confused_with_separator() {
         let input = Bytes::from_static(b"From: a@b.com\r\n\r\nPara 1\r\n\r\nPara 2\r\n");
-        let msg = Message::parse(input).unwrap();
+        let msg = Message::parse(&input).expect("valid message");
         assert_eq!(msg.body.as_bytes(), b"Para 1\r\n\r\nPara 2\r\n");
     }
 
-    /// Round-trip: parse → to_bytes must reproduce the original bytes exactly.
+    /// Round-trip: parse → `to_bytes` must reproduce the original bytes exactly.
     #[test]
     fn round_trip() {
         let original = simple_bytes();
-        let msg = Message::parse(original.clone()).unwrap();
+        let msg = Message::parse(&original).expect("valid message");
         let serialised = msg.to_bytes();
         assert_eq!(serialised, original);
     }
 
-    /// wire_len must equal the length of to_bytes().
+    /// `wire_len` must equal the length of `to_bytes()`.
     #[test]
     fn wire_len_matches_to_bytes() {
-        let msg = Message::parse(simple_bytes()).unwrap();
+        let msg = Message::parse(&simple_bytes()).expect("valid message");
         assert_eq!(msg.wire_len(), msg.to_bytes().len());
     }
 
-    /// RFC 5322 §2.1: missing CRLF CRLF separator is an error.
+    /// RFC 5322 §2.1: missing `\r\n\r\n` separator is an error.
     #[test]
     fn reject_no_separator() {
         let input = Bytes::from_static(b"From: a@b.com\r\nNo separator here");
-        assert!(Message::parse(input).is_err());
+        assert!(Message::parse(&input).is_err());
     }
 
-    /// Body bytes are a zero-copy slice of the input Bytes.
+    /// Body bytes are a zero-copy slice of the input `Bytes`.
     #[test]
     fn body_is_zero_copy_slice() {
         let original = simple_bytes();
-        let msg = Message::parse(original.clone()).unwrap();
+        let msg = Message::parse(&original).expect("valid message");
         // The body slice should share the same underlying allocation.
         assert_eq!(
             msg.body.as_bytes().as_ptr() as usize,
-            original[original.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4..].as_ptr()
-                as usize
+            original[original
+                .windows(4)
+                .position(|w| w == b"\r\n\r\n")
+                .expect("separator present")
+                + 4..]
+                .as_ptr() as usize
         );
     }
 }

--- a/crates/lmtp/src/codec.rs
+++ b/crates/lmtp/src/codec.rs
@@ -57,12 +57,14 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 50 * 1024 * 1024; // 50 MiB
 #[derive(Debug, Default)]
 pub struct CommandCodec {
     /// Maximum line length before returning an error.
+    #[expect(dead_code, reason = "stub: enforced in decode() once implemented")]
     max_line: usize,
 }
 
 impl CommandCodec {
     /// Construct a [`CommandCodec`] with the default command-line length limit.
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         Self {
             max_line: MAX_COMMAND_LINE,
         }
@@ -97,12 +99,14 @@ impl Encoder<&str> for CommandCodec {
 #[derive(Debug)]
 pub struct DataCodec {
     /// Maximum total body size before returning an error.
+    #[expect(dead_code, reason = "stub: enforced in decode() once implemented")]
     max_size: usize,
 }
 
 impl DataCodec {
     /// Construct a [`DataCodec`] with a configurable maximum message size.
-    pub fn new(max_size: usize) -> Self {
+    #[must_use]
+    pub const fn new(max_size: usize) -> Self {
         Self { max_size }
     }
 }

--- a/crates/lmtp/src/command.rs
+++ b/crates/lmtp/src/command.rs
@@ -123,14 +123,14 @@ impl Command {
 impl std::fmt::Display for Command {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Command::Lhlo { client_domain } => write!(f, "LHLO {client_domain}"),
-            Command::Mail { from, .. } => write!(f, "MAIL FROM:{from}"),
-            Command::Rcpt { to, .. } => write!(f, "RCPT TO:<{to}>"),
-            Command::Data => f.write_str("DATA"),
-            Command::Rset => f.write_str("RSET"),
-            Command::Noop => f.write_str("NOOP"),
-            Command::Vrfy { query } => write!(f, "VRFY {query}"),
-            Command::Quit => f.write_str("QUIT"),
+            Self::Lhlo { client_domain } => write!(f, "LHLO {client_domain}"),
+            Self::Mail { from, .. } => write!(f, "MAIL FROM:{from}"),
+            Self::Rcpt { to, .. } => write!(f, "RCPT TO:<{to}>"),
+            Self::Data => f.write_str("DATA"),
+            Self::Rset => f.write_str("RSET"),
+            Self::Noop => f.write_str("NOOP"),
+            Self::Vrfy { query } => write!(f, "VRFY {query}"),
+            Self::Quit => f.write_str("QUIT"),
         }
     }
 }

--- a/crates/lmtp/src/lib.rs
+++ b/crates/lmtp/src/lib.rs
@@ -65,8 +65,6 @@
 //! - [`session`] – session state machine.
 //! - [`server`]  – TCP/Unix-socket listener that spawns sessions.
 
-#![warn(missing_docs)]
-
 pub mod codec;
 pub mod command;
 pub mod response;

--- a/crates/lmtp/src/response.rs
+++ b/crates/lmtp/src/response.rs
@@ -41,73 +41,78 @@ impl ReplyCode {
     // ── Frequently used codes ────────────────────────────────────────────────
 
     /// `211 System status` (RFC 5321).
-    pub const SYSTEM_STATUS: ReplyCode = ReplyCode(211);
+    pub const SYSTEM_STATUS: Self = Self(211);
     /// `214 Help message` (RFC 5321).
-    pub const HELP: ReplyCode = ReplyCode(214);
+    pub const HELP: Self = Self(214);
     /// `220 <domain> Service ready` – sent immediately after TCP connection.
-    pub const SERVICE_READY: ReplyCode = ReplyCode(220);
+    pub const SERVICE_READY: Self = Self(220);
     /// `221 <domain> Service closing` – sent in response to `QUIT`.
-    pub const SERVICE_CLOSING: ReplyCode = ReplyCode(221);
+    pub const SERVICE_CLOSING: Self = Self(221);
     /// `250 Requested mail action okay, completed`.
-    pub const OK: ReplyCode = ReplyCode(250);
+    pub const OK: Self = Self(250);
     /// `252 Cannot VRFY user, but will accept message and attempt delivery`.
-    pub const CANNOT_VRFY: ReplyCode = ReplyCode(252);
+    pub const CANNOT_VRFY: Self = Self(252);
     /// `354 Start mail input; end with <CRLF>.<CRLF>` – response to `DATA`.
-    pub const START_MAIL_INPUT: ReplyCode = ReplyCode(354);
+    pub const START_MAIL_INPUT: Self = Self(354);
     /// `421 <domain> Service not available, closing channel`.
-    pub const SERVICE_UNAVAILABLE: ReplyCode = ReplyCode(421);
+    pub const SERVICE_UNAVAILABLE: Self = Self(421);
     /// `450 Requested mail action not taken: mailbox unavailable` (transient).
-    pub const MAILBOX_UNAVAILABLE_TRANSIENT: ReplyCode = ReplyCode(450);
+    pub const MAILBOX_UNAVAILABLE_TRANSIENT: Self = Self(450);
     /// `451 Requested action aborted: local error in processing`.
-    pub const LOCAL_ERROR: ReplyCode = ReplyCode(451);
+    pub const LOCAL_ERROR: Self = Self(451);
     /// `452 Requested action not taken: insufficient system storage`.
-    pub const INSUFFICIENT_STORAGE_TRANSIENT: ReplyCode = ReplyCode(452);
+    pub const INSUFFICIENT_STORAGE_TRANSIENT: Self = Self(452);
     /// `500 Syntax error, command unrecognised`.
-    pub const SYNTAX_ERROR: ReplyCode = ReplyCode(500);
+    pub const SYNTAX_ERROR: Self = Self(500);
     /// `501 Syntax error in parameters or arguments`.
-    pub const PARAM_SYNTAX_ERROR: ReplyCode = ReplyCode(501);
+    pub const PARAM_SYNTAX_ERROR: Self = Self(501);
     /// `502 Command not implemented`.
-    pub const NOT_IMPLEMENTED: ReplyCode = ReplyCode(502);
+    pub const NOT_IMPLEMENTED: Self = Self(502);
     /// `503 Bad sequence of commands`.
-    pub const BAD_SEQUENCE: ReplyCode = ReplyCode(503);
+    pub const BAD_SEQUENCE: Self = Self(503);
     /// `504 Command parameter not implemented`.
-    pub const PARAM_NOT_IMPLEMENTED: ReplyCode = ReplyCode(504);
+    pub const PARAM_NOT_IMPLEMENTED: Self = Self(504);
     /// `550 Requested action not taken: mailbox unavailable` (permanent).
-    pub const MAILBOX_UNAVAILABLE: ReplyCode = ReplyCode(550);
+    pub const MAILBOX_UNAVAILABLE: Self = Self(550);
     /// `552 Requested mail action aborted: exceeded storage allocation`.
-    pub const STORAGE_EXCEEDED: ReplyCode = ReplyCode(552);
+    pub const STORAGE_EXCEEDED: Self = Self(552);
     /// `554 Transaction failed / No SMTP service here`.
-    pub const TRANSACTION_FAILED: ReplyCode = ReplyCode(554);
+    pub const TRANSACTION_FAILED: Self = Self(554);
 
     /// Construct a reply code from a raw `u16`.
     ///
     /// # Panics
     ///
     /// Panics if `code` is not in `200..=599`.
+    #[must_use]
     pub fn new(code: u16) -> Self {
         assert!(
             (200..=599).contains(&code),
             "reply code out of range: {code}"
         );
-        ReplyCode(code)
+        Self(code)
     }
 
     /// The numeric value.
-    pub fn as_u16(self) -> u16 {
+    #[must_use]
+    pub const fn as_u16(self) -> u16 {
         self.0
     }
 
-    /// True if this is a positive-completion code (2xx).
+    /// True if this is a positive-completion code (`2xx`).
+    #[must_use]
     pub fn is_positive(&self) -> bool {
         (200..300).contains(&self.0)
     }
 
-    /// True if this is a transient failure (4xx).
+    /// True if this is a transient failure (`4xx`).
+    #[must_use]
     pub fn is_transient(&self) -> bool {
         (400..500).contains(&self.0)
     }
 
-    /// True if this is a permanent failure (5xx).
+    /// True if this is a permanent failure (`5xx`).
+    #[must_use]
     pub fn is_permanent(&self) -> bool {
         (500..600).contains(&self.0)
     }
@@ -137,6 +142,7 @@ pub struct Reply {
 
 impl Reply {
     /// Construct a single-line reply.
+    #[must_use]
     pub fn new(code: ReplyCode, text: impl Into<String>) -> Self {
         Self {
             code,
@@ -145,17 +151,21 @@ impl Reply {
     }
 
     /// Construct a multi-line reply (e.g. `LHLO` extension listing).
+    #[must_use]
     pub fn multi(code: ReplyCode, lines: Vec<String>) -> Self {
         assert!(!lines.is_empty(), "reply must have at least one line");
         Self { code, lines }
     }
 
-    /// Render the reply to its wire representation including CRLF terminators.
+    /// Render the reply to its wire representation including `CRLF` terminators.
+    #[must_use]
     pub fn to_wire(&self) -> String {
+        use std::fmt::Write as _;
         let mut out = String::new();
         for (i, line) in self.lines.iter().enumerate() {
             let sep = if i + 1 == self.lines.len() { ' ' } else { '-' };
-            out.push_str(&format!("{}{}{}\r\n", self.code, sep, line));
+            write!(out, "{}{}{}\r\n", self.code, sep, line)
+                .expect("writing to String is infallible");
         }
         out
     }
@@ -163,6 +173,7 @@ impl Reply {
     // ── Common replies ───────────────────────────────────────────────────────
 
     /// `220 <hostname> LMTP service ready`
+    #[must_use]
     pub fn greeting(hostname: &str) -> Self {
         Self::new(
             ReplyCode::SERVICE_READY,
@@ -171,16 +182,19 @@ impl Reply {
     }
 
     /// `221 <hostname> Bye`
+    #[must_use]
     pub fn closing(hostname: &str) -> Self {
         Self::new(ReplyCode::SERVICE_CLOSING, format!("{hostname} Bye"))
     }
 
     /// `250 OK`
+    #[must_use]
     pub fn ok() -> Self {
         Self::new(ReplyCode::OK, "OK")
     }
 
     /// `354 End data with <CR><LF>.<CR><LF>`
+    #[must_use]
     pub fn start_data() -> Self {
         Self::new(
             ReplyCode::START_MAIL_INPUT,
@@ -189,6 +203,7 @@ impl Reply {
     }
 
     /// `500 Syntax error, command unrecognised`
+    #[must_use]
     pub fn syntax_error() -> Self {
         Self::new(
             ReplyCode::SYNTAX_ERROR,
@@ -197,6 +212,7 @@ impl Reply {
     }
 
     /// `503 Bad sequence of commands`
+    #[must_use]
     pub fn bad_sequence() -> Self {
         Self::new(ReplyCode::BAD_SEQUENCE, "Bad sequence of commands")
     }

--- a/crates/lmtp/src/server.rs
+++ b/crates/lmtp/src/server.rs
@@ -76,7 +76,8 @@ pub struct Server<H: MessageHandler + Clone + 'static> {
 
 impl<H: MessageHandler + Clone + 'static> Server<H> {
     /// Construct a new server with the given configuration and message handler.
-    pub fn new(config: ServerConfig, handler: H) -> Self {
+    #[must_use]
+    pub const fn new(config: ServerConfig, handler: H) -> Self {
         Self { config, handler }
     }
 
@@ -104,6 +105,10 @@ impl<H: MessageHandler + Clone + 'static> Server<H> {
     }
 
     /// Bind to a Unix domain socket and serve connections.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the Unix socket `accept` call fails.
     pub async fn serve_unix(self, listener: UnixListener) -> Result<()> {
         let config = Arc::new(self.config);
         info!("LMTP server listening (Unix socket)");
@@ -123,6 +128,10 @@ impl<H: MessageHandler + Clone + 'static> Server<H> {
     ///
     /// `S` must implement both `AsyncRead` and `AsyncWrite` (satisfied by
     /// `TcpStream` and `UnixStream`).
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will drive framed session once implemented"
+    )]
     async fn run_session<S>(_config: Arc<ServerConfig>, _handler: H, _stream: S) -> Result<()>
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,

--- a/crates/lmtp/src/session.rs
+++ b/crates/lmtp/src/session.rs
@@ -129,7 +129,9 @@ pub trait MessageHandler: Send + Sync {
 pub struct Session<H: MessageHandler> {
     /// The server's hostname, used in greeting and `QUIT` responses.
     pub hostname: String,
+    #[expect(dead_code, reason = "stub: used by handle_command() once implemented")]
     state: SessionState,
+    #[expect(dead_code, reason = "stub: used by receive_data() once implemented")]
     handler: H,
 }
 
@@ -156,9 +158,18 @@ impl<H: MessageHandler> Session<H> {
     /// For most commands this is a single reply. For `DATA`, the session
     /// accumulates the message body separately via [`Session::receive_data`].
     ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::OutOfSequence`] if the command is not valid in
+    /// the current session state.
+    ///
     /// # State transitions
     ///
     /// See the module-level state diagram.
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await handler once implemented"
+    )]
     pub async fn handle_command(&mut self, _command: crate::command::Command) -> Result<Reply> {
         todo!(
             "match self.state and command; transition state; \
@@ -172,6 +183,11 @@ impl<H: MessageHandler> Session<H> {
     /// Returns one [`Reply`] per recipient (in the order they were accepted).
     /// The caller must send all of them before reading the next command.
     ///
+    /// # Errors
+    ///
+    /// Returns an error if message parsing fails or the handler returns an
+    /// error.
+    ///
     /// # Dot-unstuffing
     ///
     /// The raw bytes received from the codec already have dot-stuffing removed
@@ -181,6 +197,10 @@ impl<H: MessageHandler> Session<H> {
     ///
     /// On success, resets to [`SessionState::Greeted`] so the client can begin
     /// a new transaction.
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await handler once implemented"
+    )]
     pub async fn receive_data(&mut self, _raw: bytes::Bytes) -> Result<Vec<Reply>> {
         todo!(
             "parse Message from raw bytes; call self.handler.handle(envelope, message); \

--- a/crates/service/src/config.rs
+++ b/crates/service/src/config.rs
@@ -101,7 +101,7 @@ pub enum ListenConfig {
     },
 }
 
-fn default_socket_mode() -> u32 {
+const fn default_socket_mode() -> u32 {
     0o600
 }
 
@@ -197,7 +197,7 @@ impl Default for ServerSettings {
     }
 }
 
-fn default_max_message_size() -> usize {
+const fn default_max_message_size() -> usize {
     50 * 1024 * 1024
 }
 
@@ -226,7 +226,7 @@ impl Config {
         let default_path = PathBuf::from("/etc/lmtp-dkim/config.toml");
         let effective_path = path.unwrap_or(&default_path);
         let raw = std::fs::read_to_string(effective_path)?;
-        let config: Config = toml::from_str(&raw)?;
+        let config: Self = toml::from_str(&raw)?;
         config.validate()?;
         Ok(config)
     }

--- a/crates/service/src/inbound.rs
+++ b/crates/service/src/inbound.rs
@@ -49,6 +49,10 @@ use std::sync::Arc as StdArc;
 
 use email_primitives::Message;
 use lmtp::session::{Envelope, MessageHandler, RecipientResult};
+#[expect(
+    unused_imports,
+    reason = "stub: tracing macros used when run() is implemented"
+)]
 use tracing::{error, info, warn};
 
 use crate::config::Config;
@@ -57,6 +61,10 @@ use crate::config::Config;
 ///
 /// Binds to the configured listen socket, creates the signing infrastructure,
 /// and serves connections.
+#[expect(
+    clippy::unused_async,
+    reason = "stub: will await server.serve_* once implemented"
+)]
 pub async fn run(config: Config) -> anyhow::Result<()> {
     let _ = config;
     todo!(
@@ -71,10 +79,15 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
 /// LMTP [`MessageHandler`] for the inbound pipeline.
 #[derive(Clone)]
+#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
 pub struct InboundHandler {
     inner: StdArc<InboundHandlerInner>,
 }
 
+#[expect(
+    dead_code,
+    reason = "stub: fields used by MessageHandler::handle once implemented"
+)]
 struct InboundHandlerInner {
     arc_signer: arc::ArcSigner,
     dkim_verifier: dkim::Verifier,
@@ -106,6 +119,10 @@ impl MessageHandler for InboundHandler {
 ///
 /// Initiates an LMTP session (sends LHLO, MAIL FROM, RCPT TO ×N, DATA)
 /// and collects per-recipient responses.
+#[expect(
+    dead_code,
+    reason = "stub: constructed in InboundHandlerInner once implemented"
+)]
 struct DownstreamClient {
     // connection pool or address config
 }
@@ -115,6 +132,14 @@ impl DownstreamClient {
     ///
     /// Returns one [`RecipientResult`] per entry in `envelope.recipients`,
     /// suitable for passing back to the upstream client.
+    #[expect(
+        dead_code,
+        reason = "stub: called by MessageHandler::handle once implemented"
+    )]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await LMTP connection once implemented"
+    )]
     async fn deliver(
         &self,
         _envelope: &Envelope,

--- a/crates/service/src/main.rs
+++ b/crates/service/src/main.rs
@@ -43,8 +43,6 @@
 //! lmtp-dkim --config /etc/lmtp-dkim/outbound.toml
 //! ```
 
-#![warn(missing_docs)]
-
 mod config;
 mod inbound;
 mod outbound;

--- a/crates/service/src/outbound.rs
+++ b/crates/service/src/outbound.rs
@@ -44,11 +44,19 @@ use std::sync::Arc as StdArc;
 
 use email_primitives::Message;
 use lmtp::session::{Envelope, MessageHandler, RecipientResult};
+#[expect(
+    unused_imports,
+    reason = "stub: tracing macros used when run() is implemented"
+)]
 use tracing::{info, warn};
 
 use crate::config::Config;
 
 /// Run the outbound LMTP server.
+#[expect(
+    clippy::unused_async,
+    reason = "stub: will await server.serve_* once implemented"
+)]
 pub async fn run(config: Config) -> anyhow::Result<()> {
     let _ = config;
     todo!(
@@ -62,10 +70,15 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
 /// LMTP [`MessageHandler`] for the outbound pipeline.
 #[derive(Clone)]
+#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
 pub struct OutboundHandler {
     inner: StdArc<OutboundHandlerInner>,
 }
 
+#[expect(
+    dead_code,
+    reason = "stub: fields used by MessageHandler::handle once implemented"
+)]
 struct OutboundHandlerInner {
     /// Map from lowercase domain string to configured signer.
     ///
@@ -96,11 +109,23 @@ impl MessageHandler for OutboundHandler {
 ///
 /// Identical in structure to the inbound [`crate::inbound::DownstreamClient`];
 /// consider extracting to a shared module once both modes are implemented.
+#[expect(
+    dead_code,
+    reason = "stub: constructed in OutboundHandlerInner once implemented"
+)]
 struct DownstreamClient {
     // connection pool or address config
 }
 
 impl DownstreamClient {
+    #[expect(
+        dead_code,
+        reason = "stub: called by MessageHandler::handle once implemented"
+    )]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await LMTP connection once implemented"
+    )]
     async fn deliver(
         &self,
         _envelope: &Envelope,


### PR DESCRIPTION
## Summary

- Enables `clippy::all`, `clippy::pedantic`, and `clippy::nursery` at `deny` level in `[workspace.lints.clippy]`, plus selected `clippy::restriction` lints (`allow_attributes_without_reason`, `unwrap_used`)
- Denies `rust::dead_code`, `rust::missing_docs`, and `rust::unused_imports` at workspace level; warns on `unreachable_pub`
- Fixes all genuine violations in implemented code across all five crates
- Annotates stub functions/fields/imports with `#[expect(lint, reason = "stub: ...")]` so the compiler will error if a stub is filled in without removing the suppression
- Three project-wide `allow`s kept: `missing_panics_doc` (every `todo!()` panics), `module_name_repetitions` (conventional for re-exported types), `wildcard_imports` (idiomatic in test modules)

## Lint violations fixed

- **`use_self`** — replaced type name with `Self` in `impl` blocks (`match`, constants, constructors) across `lmtp`, `dkim`, `arc`, `service`
- **`must_use_candidate`** — added `#[must_use]` to all pure functions returning values
- **`missing_errors_doc`** — added `# Errors` sections to all `Result`-returning public functions
- **`doc_markdown`** — backtick-quoted code-like identifiers in doc comments throughout
- **`missing_const_for_fn`** — made constructors and simple accessors `const fn`
- **`format_push_string`** — replaced `push_str(&format!(...))` with `write!(string, ...)` in `Reply::to_wire()`
- **`inherent_to_string`** — replaced `fn to_string()` on `AuthResultsValue` with a `Display` impl
- **`unused_async`** — annotated all stub `async fn`s that have no `.await`

## Test plan

- [ ] `cargo clippy --workspace --all-targets` — zero warnings or errors
- [ ] `cargo fmt --check` — no formatting differences
- [ ] `cargo check --workspace --all-targets` — compiles cleanly
- [ ] CI passes

https://claude.ai/code/session_01XivD3Dt1rWJ53JZDH4rDnK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XivD3Dt1rWJ53JZDH4rDnK)_