### PR TITLE
Upgrade dependencies, tighten lints, refactor email-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,10 @@ dependencies = [
  "email-primitives",
  "hickory-resolver",
  "ring",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
- "winnow 0.6.26",
+ "winnow",
 ]
 
 [[package]]
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +111,12 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
@@ -127,6 +139,17 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
 
 [[package]]
 name = "clap"
@@ -175,6 +198,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,31 +288,25 @@ dependencies = [
  "email-primitives",
  "hickory-resolver",
  "ring",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
- "winnow 0.6.26",
+ "winnow",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "email-primitives"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "thiserror 2.0.18",
- "winnow 0.6.26",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror",
+ "winnow",
 ]
 
 [[package]]
@@ -248,6 +330,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -280,6 +368,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -315,6 +415,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,23 +450,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
+ "jni",
  "rand",
- "thiserror 1.0.69",
+ "thiserror",
  "tinyvec",
  "tokio",
  "tracing",
@@ -351,22 +474,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand",
+ "ring",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
  "rand",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -454,6 +602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,7 +635,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -502,6 +658,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -510,22 +669,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
@@ -539,11 +765,11 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "email-primitives",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
- "winnow 0.6.26",
+ "winnow",
 ]
 
 [[package]]
@@ -560,15 +786,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "matchers"
@@ -597,6 +814,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,10 +846,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -653,6 +906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,12 +921,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
+name = "prefix-trie"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
 dependencies = [
- "zerocopy",
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -689,34 +960,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.6"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
+name = "rand"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -758,10 +1022,34 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -769,6 +1057,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -801,12 +1095,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
+name = "serde_json"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "itoa",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -822,7 +1129,7 @@ dependencies = [
  "hickory-resolver",
  "lmtp",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -853,6 +1160,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -911,13 +1234,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.69"
+name = "system-configuration"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "thiserror-impl 1.0.69",
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
 ]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "thiserror"
@@ -925,18 +1266,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1027,44 +1357,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.22.27"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_write",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1134,6 +1462,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,10 +1498,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1176,10 +1531,116 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"
@@ -1300,20 +1761,105 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "memchr",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1343,26 +1889,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1418,3 +1944,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 bytes = "1"
 
 # Parsing (winnow is the modern successor to nom; zero-copy, combinator-based)
-winnow = "0.6"
+winnow = "1"
 
 # Cryptography
 # ring provides RSA-PKCS1v15-SHA256 and Ed25519, the two DKIM algorithms
@@ -39,7 +39,7 @@ base64 = "0.22"
 
 # DNS – used to look up DKIM public keys (_domainkey TXT records, RFC 6376 §3.6)
 # and for SPF/DMARC lookups in the service.
-hickory-resolver = "0.24"
+hickory-resolver = "0.26.0"
 
 # Error handling
 thiserror = "2"
@@ -50,7 +50,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 # Configuration and CLI (service crate only)
 serde = { version = "1", features = ["derive"] }
-toml  = "0.8"
+toml  = "1"
 clap  = { version = "4", features = ["derive", "env"] }
 
 # Error propagation in binaries (not for libraries)
@@ -59,18 +59,44 @@ anyhow = "1"
 [workspace.lints.rust]
 dead_code       = "deny"
 missing_docs    = "deny"
-unreachable_pub = "warn"
+unreachable_pub = "deny"
 unused_imports  = "deny"
+
+# Lint enforcement
+unfulfilled_lint_expectations = "deny"
 
 [workspace.lints.clippy]
 # Lint groups (lower priority so individual overrides take effect)
-all      = { level = "deny", priority = -3 }
 pedantic = { level = "deny", priority = -2 }
-nursery  = { level = "deny", priority = -1 }
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }
+
 # Selected restriction lints
+allow_attributes = "deny"
 allow_attributes_without_reason = "deny"
-unwrap_used                      = "deny"
+arbitrary_source_item_ordering = "deny"
+as_pointer_underscore = "deny"
+assertions_on_result_states = "deny"
+cfg_not_test = "deny"
+clone_on_ref_ptr = "deny"
+derive_partial_eq_without_eq = "deny"
+exhaustive_enums = "deny"
+exhaustive_structs = "deny"
+expect_used = "deny"
+fn_to_numeric_cast_any = "deny"
+if_then_some_else_none = "deny"
+impl_trait_in_params = "deny"
+#indexing_slicing = "deny"
+map_err_ignore = "deny"
+missing_assert_message = "deny"
+missing_asserts_for_indexing = "deny"
+mixed_read_write_in_expression = "deny"
+panic = "deny"
+unwrap_used = "deny"
 # Project-wide allowances
-missing_panics_doc      = "allow"  # stubs use todo!() which panics; revisit once implemented
+missing_panics_doc = "allow"  # stubs use todo!() which panics; revisit once implemented
 module_name_repetitions = "allow"  # conventional for re-exported types (e.g. dkim::DkimSignature)
-wildcard_imports        = "allow"  # idiomatic in test modules (use super::*)
+wildcard_imports        = "deny"  # idiomatic in test modules (use super::*)

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+allow-expect-in-tests = true
+allow-indexing-slicing-in-tests = true
+source-item-ordering = ["module"]

--- a/crates/arc/src/auth_results.rs
+++ b/crates/arc/src/auth_results.rs
@@ -45,6 +45,7 @@
 /// A single method result within an `Authentication-Results` header.
 ///
 /// Corresponds to one `; method=result ...` clause.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct AuthResultsValue {
     /// The method name, e.g. `"dkim"`, `"spf"`, `"dmarc"`, `"arc"`.
@@ -67,6 +68,7 @@ pub struct AuthResultsValue {
 /// A single property within a method result.
 ///
 /// Encoded as `<ptype>.<property>=<value>` in the header.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct AuthResultProperty {
     /// The property type, e.g. `"header"`, `"smtp"`, `"policy"`.

--- a/crates/arc/src/chain.rs
+++ b/crates/arc/src/chain.rs
@@ -37,6 +37,7 @@ use crate::Result;
 use crate::headers::ArcSet;
 
 /// The result of validating an ARC chain.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArcChainResult {
     /// No ARC headers were present.
@@ -60,6 +61,7 @@ impl ArcChainResult {
 }
 
 /// The output of a successful chain validation.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ChainValidationOutput {
     /// The overall chain result.

--- a/crates/arc/src/headers.rs
+++ b/crates/arc/src/headers.rs
@@ -38,7 +38,7 @@
 //!     t=1234567890; b=...
 //! ```
 
-use email_primitives::Domain;
+use email_primitives::address::Domain;
 
 use crate::auth_results::AuthResultsValue;
 use crate::chain::ArcChainResult;
@@ -50,6 +50,7 @@ use crate::{Error, Result};
 /// RFC 8617 §5.1.1: a Participating Forwarder that observes `cv=fail` SHOULD
 /// still add its own ARC set (to preserve the chain history) but must set
 /// `cv=fail` in its own Seal.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChainValidation {
     /// `cv=none` – no ARC headers were present before this hop; this is the
@@ -98,6 +99,7 @@ impl From<ArcChainResult> for ChainValidation {
 }
 
 /// A parsed `ARC-Authentication-Results` header.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct AuthenticationResults {
     /// `i=` – instance number.
@@ -132,6 +134,7 @@ impl AuthenticationResults {
 ///
 /// Shares the same tag-value format as `DKIM-Signature` plus `i=`.
 /// The signing and verification logic is delegated to the `dkim` crate.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ArcMessageSignature {
     /// `i=` – instance number.
@@ -164,6 +167,7 @@ impl ArcMessageSignature {
 }
 
 /// A parsed `ARC-Seal` header.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ArcSeal {
     /// `i=` – instance number.
@@ -212,6 +216,7 @@ impl ArcSeal {
 ///
 /// A well-formed message with ARC has one [`ArcSet`] per instance number,
 /// with contiguous instance numbers starting at 1.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ArcSet {
     /// The instance number (1-based).

--- a/crates/arc/src/lib.rs
+++ b/crates/arc/src/lib.rs
@@ -85,6 +85,7 @@ use thiserror::Error;
 pub const MAX_INSTANCE: u32 = 50;
 
 /// Errors that can arise during ARC processing.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     /// An ARC header field could not be parsed.

--- a/crates/arc/src/seal.rs
+++ b/crates/arc/src/seal.rs
@@ -59,6 +59,7 @@ use crate::chain::ArcChainResult;
 use crate::headers::ArcSet;
 
 /// Parameters for adding an ARC set to a message.
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct SealRequest {
     /// The authentication service identifier (typically the hostname of this

--- a/crates/dkim/src/dns.rs
+++ b/crates/dkim/src/dns.rs
@@ -35,7 +35,7 @@
 //! `hickory-resolver` internal cache. This avoids repeated DNS lookups for
 //! the same key within its TTL window.
 
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::TokioResolver;
 
 #[expect(
     unused_imports,
@@ -46,6 +46,7 @@ use crate::Result;
 use crate::key::PublicKey;
 
 /// A parsed DKIM DNS record.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct DkimDnsRecord {
     /// `v=` – version. If present must be `DKIM1`; if absent, assume `DKIM1`.
@@ -65,6 +66,7 @@ pub struct DkimDnsRecord {
 }
 
 /// Key type from the `k=` DNS tag.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyType {
     /// `k=rsa` – RSA public key in `SubjectPublicKeyInfo` (SPKI) DER format,
@@ -76,6 +78,7 @@ pub enum KeyType {
 }
 
 /// Flags from the `t=` DNS tag.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DnsFlag {
     /// `y` – the domain is in testing mode. Verifiers SHOULD NOT treat test
@@ -117,7 +120,7 @@ impl DkimDnsRecord {
 /// (e.g. via `Arc`) to benefit from the internal DNS cache.
 pub struct DkimResolver {
     #[expect(dead_code, reason = "stub: used by lookup() once implemented")]
-    inner: TokioAsyncResolver,
+    inner: TokioResolver,
 }
 
 impl DkimResolver {
@@ -127,10 +130,6 @@ impl DkimResolver {
     /// # Errors
     ///
     /// Returns an error if the system resolver configuration cannot be read.
-    #[expect(
-        clippy::unused_async,
-        reason = "stub: will await resolver once implemented"
-    )]
     pub async fn from_system_conf() -> Result<Self> {
         todo!("TokioAsyncResolver::from_system_conf(ResolverOpts::default())")
     }

--- a/crates/dkim/src/key.rs
+++ b/crates/dkim/src/key.rs
@@ -32,6 +32,7 @@ use crate::Result;
 /// A DKIM private key, used for signing.
 ///
 /// Wraps the `ring` key material. Key material is zeroed on drop by `ring`.
+#[non_exhaustive]
 pub enum PrivateKey {
     /// RSA private key. Minimum 2048-bit recommended (RFC 8301).
     Rsa(ring::signature::RsaKeyPair),
@@ -110,6 +111,7 @@ impl PrivateKey {
 /// A DKIM public key, used for verification.
 ///
 /// Constructed from DNS TXT record data by [`crate::dns::DkimDnsRecord`].
+#[non_exhaustive]
 pub enum PublicKey {
     /// RSA public key.
     Rsa(ring::signature::UnparsedPublicKey<Vec<u8>>),

--- a/crates/dkim/src/lib.rs
+++ b/crates/dkim/src/lib.rs
@@ -84,6 +84,7 @@ pub use verify::{VerificationResult, VerificationStatus, Verifier};
 use thiserror::Error;
 
 /// Errors that can arise during DKIM signing or verification.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     /// A tag-list could not be parsed.

--- a/crates/dkim/src/sign.rs
+++ b/crates/dkim/src/sign.rs
@@ -37,18 +37,13 @@
 //!   only appears once in the message. This prevents an attacker from
 //!   prepending a second occurrence of that header after signing.
 
-use email_primitives::{Domain, Message};
-
 use crate::Result;
 use crate::key::PrivateKey;
 use crate::signature::Canonicalization;
-#[expect(
-    unused_imports,
-    reason = "stub: DkimSignature used when sign() is implemented"
-)]
-use crate::signature::DkimSignature;
-
+use email_primitives::Message;
+use email_primitives::address::Domain;
 /// Parameters for a DKIM signing operation.
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct SignRequest {
     /// `d=` – the signing domain. Must be the same as or a parent of the
@@ -81,7 +76,7 @@ impl SignRequest {
     /// Default header list covers the fields recommended by RFC 6376 §5.4.1
     /// plus "over-signing" of `From:` and `To:`.
     #[must_use]
-    pub fn new(domain: Domain, selector: impl Into<String>) -> Self {
+    pub fn new<S: Into<String>>(domain: Domain, selector: S) -> Self {
         Self {
             domain,
             selector: selector.into(),

--- a/crates/dkim/src/signature.rs
+++ b/crates/dkim/src/signature.rs
@@ -26,7 +26,7 @@
 //! The `d=` domain must be the same as or a parent of the `From:` header
 //! domain (RFC 6376 §6.1.1 step 8).
 
-use email_primitives::Domain;
+use email_primitives::address::Domain;
 
 #[expect(
     unused_imports,
@@ -38,6 +38,7 @@ use crate::{Error, Result};
 /// The signing algorithm used in `a=`.
 ///
 /// See RFC 6376 §3.3 and RFC 8463 for the Ed25519 variant.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Algorithm {
     /// `rsa-sha256` (RFC 6376 §3.3.1). RSA with PKCS#1 v1.5 padding and SHA-256.
@@ -84,6 +85,7 @@ impl Algorithm {
 }
 
 /// The canonicalization algorithm for a single part (header or body).
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CanonicalizationAlgorithm {
     /// `simple` – minimal transformation; preserves original casing and
@@ -124,6 +126,7 @@ impl CanonicalizationAlgorithm {
 /// The `c=` tag: canonicalization algorithms for header and body.
 ///
 /// Encoded as `<header>/<body>`. Defaults to `simple/simple`.
+#[expect(clippy::exhaustive_structs, reason = "exhaustive by RFC")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Canonicalization {
     /// Algorithm for header fields.
@@ -163,6 +166,7 @@ impl Canonicalization {
 ///
 /// This struct owns the decoded, validated fields. The raw base64 data for
 /// `b=` (signature) and `bh=` (body hash) is decoded into byte vectors.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct DkimSignature {
     /// `a=` – signing algorithm.

--- a/crates/dkim/src/verify.rs
+++ b/crates/dkim/src/verify.rs
@@ -49,6 +49,7 @@ use crate::{Error, Result};
 /// The outcome of verifying a single `DKIM-Signature`.
 ///
 /// Maps to the `dkim` method results defined in RFC 7601 §2.7.1.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VerificationStatus {
     /// `pass` – the signature validated successfully.
@@ -69,6 +70,7 @@ pub enum VerificationStatus {
 }
 
 /// The result of verifying one `DKIM-Signature` header.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct VerificationResult {
     /// The overall outcome.

--- a/crates/email-primitives/src/address.rs
+++ b/crates/email-primitives/src/address.rs
@@ -28,14 +28,22 @@
 //! non-ASCII characters (RFC 5321 section 2.3.5; RFC 5891 IDNA 2008).
 //! Conversion from Unicode to Punycode is outside the scope of this crate.
 
+pub(crate) mod domain;
+pub(crate) mod local_part;
+pub(crate) mod owned_reverse_path;
+pub(crate) mod reverse_path;
+
+use crate::quotes::IterableQuoted;
+use crate::{Error, Result};
+pub use domain::Domain;
+use local_part::LocalPart;
+pub use owned_reverse_path::OwnedReversePath;
+use reverse_path::ReversePath;
 use winnow::{
     ModalResult, Parser,
-    combinator::alt,
     error::{ContextError, ErrMode},
     token::{literal, one_of, take_while},
 };
-
-use crate::{Error, Result};
 
 /// An email address of the form `local-part@domain`.
 ///
@@ -68,18 +76,18 @@ impl EmailAddress {
         // Split on the last '@' (RFC 5322 §3.4.1: local-part "@" domain).
         let at = s
             .rfind('@')
-            .ok_or_else(|| Error::InvalidAddress(input.to_owned()))?;
+            .ok_or_else(|| Error::InvalidAddress(input.to_owned(), None))?;
         let local_str = &s[..at];
         let domain_str = &s[at + 1..];
 
         if local_str.is_empty() || domain_str.is_empty() {
-            return Err(Error::InvalidAddress(input.to_owned()));
+            return Err(Error::InvalidAddress(input.to_owned(), None));
         }
 
-        let local =
-            parse_local_part(local_str).ok_or_else(|| Error::InvalidAddress(input.to_owned()))?;
-        let domain =
-            Domain::parse(domain_str).map_err(|_| Error::InvalidAddress(input.to_owned()))?;
+        let local = local_part::parse_local_part(local_str)
+            .ok_or_else(|| Error::InvalidAddress(input.to_owned(), None))?;
+        let domain = Domain::parse(domain_str)
+            .map_err(|e| Error::InvalidAddress(input.to_owned(), Some(Box::new(e))))?;
 
         Ok(Self { local, domain })
     }
@@ -183,183 +191,20 @@ fn quoted_string<'s>(input: &mut &'s str) -> ModalResult<&'s str> {
     Ok(&start[..consumed])
 }
 
-/// Parse the local-part of an address (dot-atom or quoted-string).
-fn parse_local_part(s: &str) -> Option<LocalPart> {
-    let mut input = s;
-    let result = alt((dot_atom, quoted_string)).parse_next(&mut input);
-    match result {
-        Ok(matched) if input.is_empty() && matched == s => Some(LocalPart(s.to_owned())),
-        _ => None,
-    }
-}
-
-/// The local part of an email address (left of `@`).
-///
-/// Per RFC 5321 section 4.1.2, the local part is either a `dot-atom` or a
-/// `quoted-string`. We preserve the original representation including any
-/// quoting. Two local parts that compare equal as strings are equal.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct LocalPart(pub(crate) String);
-
-impl LocalPart {
-    /// The raw string value, preserving original quoting.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for LocalPart {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-/// A DNS domain name used in email contexts.
-///
-/// Stored in lowercase ASCII (RFC 5321 section 2.3.5). Must be a valid
-/// label-dot sequence per RFC 1123 section 2.1. We do not validate that the
-/// domain actually exists in DNS; that is the responsibility of higher-level
-/// code.
-///
-/// # DKIM relevance
-///
-/// DKIM uses the domain both:
-/// - As part of the `From:` address whose domain is checked against `d=`.
-/// - Directly in `d=` (SDID) and `s=` (selector) to construct the DNS query:
-///   `<selector>._domainkey.<domain>` (RFC 6376 section 3.6.2.1).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct Domain(pub(crate) String);
-
-impl Domain {
-    /// Parse and normalise a domain string to lowercase ASCII.
-    ///
-    /// Validates label structure per RFC 1123 §2.1:
-    /// - Each label: 1–63 chars, `[A-Za-z0-9-]`, no leading or trailing hyphen.
-    /// - No empty labels (consecutive dots or trailing dot).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::InvalidDomain`] if the domain is syntactically
-    /// invalid.
-    pub fn parse(input: &str) -> Result<Self> {
-        if input.is_empty() {
-            return Err(Error::InvalidDomain(input.to_owned()));
-        }
-        // RFC 1123 §2.1: overall max 253 chars.
-        if input.len() > 253 {
-            return Err(Error::InvalidDomain(input.to_owned()));
-        }
-        for label in input.split('.') {
-            validate_label(label).map_err(|()| Error::InvalidDomain(input.to_owned()))?;
-        }
-        Ok(Self(input.to_ascii_lowercase()))
-    }
-
-    /// The domain as a lowercase ASCII string, suitable for DNS queries.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Construct the DKIM DNS query name for a given selector.
-    ///
-    /// Returns `<selector>._domainkey.<domain>` per RFC 6376 section 3.6.2.1.
-    #[must_use]
-    pub fn dkim_txt_name(&self, selector: &str) -> String {
-        format!("{}._domainkey.{}", selector, self.0)
-    }
-
-    /// Return true if `other` is the same domain or a strict subdomain of
-    /// `self`.
-    ///
-    /// Used in DKIM verification (RFC 6376 section 6.1.1 step 8): the
-    /// SDID (`d=`) must be the same as or a parent of the `From:` domain.
-    ///
-    /// Examples:
-    /// - `"example.com".is_parent_of("example.com")` → `true`
-    /// - `"example.com".is_parent_of("sub.example.com")` → `true`
-    /// - `"example.com".is_parent_of("other.com")` → `false`
-    #[must_use]
-    pub fn is_parent_of(&self, other: &Self) -> bool {
-        // Both are already lowercase, so direct comparison is correct.
-        // The ".{self}" suffix check ensures we match at a label boundary,
-        // preventing "ample.com" from being a parent of "example.com".
-        other.0 == self.0 || other.0.ends_with(&format!(".{}", self.0))
-    }
-}
-
 /// Validate a single DNS label per RFC 1123 §2.1.
 fn validate_label(label: &str) -> std::result::Result<(), ()> {
     if label.is_empty() || label.len() > 63 {
         return Err(());
     }
     let bytes = label.as_bytes();
-    if !bytes[0].is_ascii_alphanumeric() {
-        return Err(());
-    }
-    if !bytes[bytes.len() - 1].is_ascii_alphanumeric() {
-        return Err(());
-    }
-    for &b in bytes {
-        if !b.is_ascii_alphanumeric() && b != b'-' {
-            return Err(());
-        }
-    }
-    Ok(())
-}
-
-impl std::fmt::Display for Domain {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl TryFrom<&str> for Domain {
-    type Error = Error;
-
-    fn try_from(s: &str) -> Result<Self> {
-        Self::parse(s)
-    }
-}
-
-/// The reverse-path used in `MAIL FROM` (RFC 5321 section 4.1.1.2).
-///
-/// The reverse-path is either a real address or the null path `<>`, which
-/// is used for bounce messages so that bounces cannot themselves bounce
-/// (RFC 5321 section 4.5.5).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ReversePath<'a> {
-    /// A real sender address.
-    Address(&'a EmailAddress),
-    /// The null path `<>` for bounces and delivery status notifications.
-    Null,
-}
-
-impl std::fmt::Display for ReversePath<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Address(addr) => write!(f, "<{addr}>"),
-            Self::Null => f.write_str("<>"),
-        }
-    }
-}
-
-/// Owned version of [`ReversePath`] for storage in session state.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum NullPath {
-    /// A real sender address.
-    Address(EmailAddress),
-    /// The null path `<>`.
-    Null,
-}
-
-impl std::fmt::Display for NullPath {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Address(addr) => write!(f, "<{addr}>"),
-            Self::Null => f.write_str("<>"),
-        }
+    if bytes.iter().all_quoted(
+        |&first| first.is_ascii_alphanumeric(),
+        |&inner| inner.is_ascii_alphanumeric() || *inner == b'-',
+        |&last| last.is_ascii_alphanumeric(),
+    ) {
+        Ok(())
+    } else {
+        Err(())
     }
 }
 
@@ -426,31 +271,31 @@ mod rfc5322_address {
     /// RFC 5322 §3.4.1: missing `@` is rejected.
     #[test]
     fn reject_missing_at() {
-        assert!(EmailAddress::parse("userexample.com").is_err());
+        EmailAddress::parse("userexample.com").expect_err("missing @");
     }
 
     /// RFC 5322 §3.4.1: adjacent dots in dot-atom rejected.
     #[test]
     fn reject_adjacent_dots() {
-        assert!(EmailAddress::parse("us..er@example.com").is_err());
+        EmailAddress::parse("us..er@example.com").expect_err("adjacent dots");
     }
 
     /// RFC 5322 §3.4.1: leading dot in local part rejected.
     #[test]
     fn reject_leading_dot() {
-        assert!(EmailAddress::parse(".user@example.com").is_err());
+        EmailAddress::parse(".user@example.com").expect_err("leading dot");
     }
 
     /// RFC 5322 §3.4.1: trailing dot in local part rejected.
     #[test]
     fn reject_trailing_dot() {
-        assert!(EmailAddress::parse("user.@example.com").is_err());
+        EmailAddress::parse("user.@example.com").expect_err("trailing dot");
     }
 
     /// Empty local part is rejected.
     #[test]
     fn reject_empty_local() {
-        assert!(EmailAddress::parse("@example.com").is_err());
+        EmailAddress::parse("@example.com").expect_err("empty local");
     }
 
     /// Display renders as `local@domain`.
@@ -503,37 +348,37 @@ mod rfc5321_domain {
     #[test]
     fn reject_label_too_long() {
         let long_label = "a".repeat(64);
-        assert!(Domain::parse(&format!("{long_label}.com")).is_err());
+        Domain::parse(&format!("{long_label}.com")).expect_err("label too long");
     }
 
     /// RFC 1123 §2.1: label cannot start with hyphen.
     #[test]
     fn reject_hyphen_start() {
-        assert!(Domain::parse("-bad.example.com").is_err());
+        Domain::parse("-bad.example.com").expect_err("hyphen-starting label is invalid");
     }
 
     /// RFC 1123 §2.1: label cannot end with hyphen.
     #[test]
     fn reject_hyphen_end() {
-        assert!(Domain::parse("bad-.example.com").is_err());
+        Domain::parse("bad-.example.com").expect_err("hyphen-ending label is invalid");
     }
 
     /// Trailing dot is rejected (we store without trailing dot for DNS construction).
     #[test]
     fn reject_trailing_dot() {
-        assert!(Domain::parse("example.com.").is_err());
+        Domain::parse("example.com.").expect_err("trailing dot");
     }
 
     /// Empty string is rejected.
     #[test]
     fn reject_empty() {
-        assert!(Domain::parse("").is_err());
+        Domain::parse("").expect_err("empty domain");
     }
 
     /// Empty label from consecutive dots is rejected.
     #[test]
     fn reject_empty_label() {
-        assert!(Domain::parse("example..com").is_err());
+        Domain::parse("example..com").expect_err("empty label");
     }
 
     /// RFC 6376 §3.6.2.1: `dkim_txt_name` constructs correct DNS query name.

--- a/crates/email-primitives/src/address/domain.rs
+++ b/crates/email-primitives/src/address/domain.rs
@@ -1,0 +1,89 @@
+use crate::{Error, address};
+
+/// A DNS domain name used in email contexts.
+///
+/// Stored in lowercase ASCII (RFC 5321 section 2.3.5). Must be a valid
+/// label-dot sequence per RFC 1123 section 2.1. We do not validate that the
+/// domain actually exists in DNS; that is the responsibility of higher-level
+/// code.
+///
+/// # DKIM relevance
+///
+/// DKIM uses the domain both:
+/// - As part of the `From:` address whose domain is checked against `d=`.
+/// - Directly in `d=` (SDID) and `s=` (selector) to construct the DNS query:
+///   `<selector>._domainkey.<domain>` (RFC 6376 section 3.6.2.1).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Domain(pub(crate) String);
+
+impl Domain {
+    /// Parse and normalise a domain string to lowercase ASCII.
+    ///
+    /// Validates label structure per RFC 1123 §2.1:
+    /// - Each label: 1–63 chars, `[A-Za-z0-9-]`, no leading or trailing hyphen.
+    /// - No empty labels (consecutive dots or trailing dot).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidDomain`] if the domain is syntactically
+    /// invalid.
+    pub fn parse(input: &str) -> crate::Result<Self> {
+        if input.is_empty() {
+            return Err(Error::InvalidDomain(input.to_owned()));
+        }
+        // RFC 1123 §2.1: overall max 253 chars.
+        if input.len() > 253 {
+            return Err(Error::InvalidDomain(input.to_owned()));
+        }
+        for label in input.split('.') {
+            address::validate_label(label).map_err(|()| Error::InvalidDomain(input.to_owned()))?;
+        }
+        Ok(Self(input.to_ascii_lowercase()))
+    }
+
+    /// The domain as a lowercase ASCII string, suitable for DNS queries.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Construct the DKIM DNS query name for a given selector.
+    ///
+    /// Returns `<selector>._domainkey.<domain>` per RFC 6376 section 3.6.2.1.
+    #[must_use]
+    pub fn dkim_txt_name(&self, selector: &str) -> String {
+        format!("{}._domainkey.{}", selector, self.0)
+    }
+
+    /// Return true if `other` is the same domain or a strict subdomain of
+    /// `self`.
+    ///
+    /// Used in DKIM verification (RFC 6376 section 6.1.1 step 8): the
+    /// SDID (`d=`) must be the same as or a parent of the `From:` domain.
+    ///
+    /// Examples:
+    /// - `"example.com".is_parent_of("example.com")` → `true`
+    /// - `"example.com".is_parent_of("sub.example.com")` → `true`
+    /// - `"example.com".is_parent_of("other.com")` → `false`
+    #[must_use]
+    pub fn is_parent_of(&self, other: &Self) -> bool {
+        // Both are already lowercase, so direct comparison is correct.
+        // The ".{self}" suffix check ensures we match at a label boundary,
+        // preventing "ample.com" from being a parent of "example.com".
+        other.0 == self.0 || other.0.ends_with(&format!(".{}", self.0))
+    }
+}
+
+impl std::fmt::Display for Domain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TryFrom<&str> for Domain {
+    type Error = Error;
+
+    fn try_from(s: &str) -> crate::Result<Self> {
+        Self::parse(s)
+    }
+}

--- a/crates/email-primitives/src/address/local_part.rs
+++ b/crates/email-primitives/src/address/local_part.rs
@@ -1,0 +1,35 @@
+use crate::address;
+use winnow::Parser;
+use winnow::combinator::alt;
+
+/// The local part of an email address (left of `@`).
+///
+/// Per RFC 5321 section 4.1.2, the local part is either a `dot-atom` or a
+/// `quoted-string`. We preserve the original representation including any
+/// quoting. Two local parts that compare equal as strings are equal.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LocalPart(pub(crate) String);
+
+impl LocalPart {
+    /// The raw string value, preserving original quoting.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for LocalPart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Parse the local-part of an address (dot-atom or quoted-string).
+pub(crate) fn parse_local_part(s: &str) -> Option<LocalPart> {
+    let mut input = s;
+    let result = alt((address::dot_atom, address::quoted_string)).parse_next(&mut input);
+    match result {
+        Ok(matched) if input.is_empty() && matched == s => Some(LocalPart(s.to_owned())),
+        _ => None,
+    }
+}

--- a/crates/email-primitives/src/address/owned_reverse_path.rs
+++ b/crates/email-primitives/src/address/owned_reverse_path.rs
@@ -1,0 +1,18 @@
+use crate::{EmailAddress, ReversePath};
+
+/// Owned version of [`ReversePath`] for storage in session state.
+#[expect(clippy::exhaustive_enums, reason = "Genuinely exhaustive")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnedReversePath {
+    /// A real sender address.
+    Address(EmailAddress),
+    /// The null path `<>`.
+    Null,
+}
+
+impl std::fmt::Display for OwnedReversePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let r: ReversePath = self.into();
+        r.fmt(f)
+    }
+}

--- a/crates/email-primitives/src/address/reverse_path.rs
+++ b/crates/email-primitives/src/address/reverse_path.rs
@@ -1,0 +1,33 @@
+use crate::{EmailAddress, OwnedReversePath};
+
+/// The reverse-path used in `MAIL FROM` (RFC 5321 section 4.1.1.2).
+///
+/// The reverse-path is either a real address or the null path `<>`, which
+/// is used for bounce messages so that bounces cannot themselves bounce
+/// (RFC 5321 section 4.5.5).
+#[expect(clippy::exhaustive_enums, reason = "Genuinely exhaustive")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReversePath<'a> {
+    /// A real sender address.
+    Address(&'a EmailAddress),
+    /// The null path `<>` for bounces and delivery status notifications.
+    Null,
+}
+
+impl<'a> From<&'a OwnedReversePath> for ReversePath<'a> {
+    fn from(value: &'a OwnedReversePath) -> Self {
+        match value {
+            OwnedReversePath::Address(addr) => ReversePath::Address(addr),
+            OwnedReversePath::Null => ReversePath::Null,
+        }
+    }
+}
+
+impl std::fmt::Display for ReversePath<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Address(addr) => write!(f, "<{addr}>"),
+            Self::Null => f.write_str("<>"),
+        }
+    }
+}

--- a/crates/email-primitives/src/error.rs
+++ b/crates/email-primitives/src/error.rs
@@ -3,7 +3,8 @@
 use thiserror::Error;
 
 /// Errors arising from parsing or validating email primitives.
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// A header field name contained characters outside the printable US-ASCII
     /// range 33–126 or included a colon (RFC 5322 section 2.2).
@@ -17,7 +18,7 @@ pub enum Error {
 
     /// An email address could not be parsed per RFC 5321 section 4.1.2.
     #[error("invalid email address: {0:?}")]
-    InvalidAddress(String),
+    InvalidAddress(String, #[source] Option<Box<dyn std::error::Error>>),
 
     /// A domain name was syntactically invalid (RFC 5321 section 4.1.2,
     /// RFC 1123 section 2.1).

--- a/crates/email-primitives/src/header.rs
+++ b/crates/email-primitives/src/header.rs
@@ -30,6 +30,11 @@
 //! duplicates.
 
 use crate::{Error, Result};
+use bytes::Bytes;
+use winnow::Parser;
+use winnow::combinator::terminated;
+use winnow::error::{ContextError, StrContext};
+use winnow::token::{rest, take_until};
 
 /// The name portion of a header field (`field-name` per RFC 5322 section 2.2).
 ///
@@ -52,7 +57,7 @@ impl HeaderName {
     ///
     /// Returns [`Error::InvalidHeaderName`] if the name is empty, contains
     /// characters outside printable US-ASCII (33–126), or contains a colon.
-    pub fn new(name: impl Into<String>) -> Result<Self> {
+    pub fn new<T: Into<String>>(name: T) -> Result<Self> {
         let s: String = name.into();
         if s.is_empty() {
             return Err(Error::InvalidHeaderName(s));
@@ -125,7 +130,7 @@ impl HeaderValue {
     ///
     /// Returns [`Error::InvalidHeaderValue`] if the value contains bare CR or
     /// LF outside of `CRLF`-WSP folding sequences.
-    pub fn new(value: impl Into<String>) -> Result<Self> {
+    pub fn new<T: Into<String>>(value: T) -> Result<Self> {
         let s: String = value.into();
         let bytes = s.as_bytes();
         let mut i = 0;
@@ -183,6 +188,7 @@ impl std::fmt::Display for HeaderValue {
 ///
 /// Note that the value typically starts with a space (e.g. `Subject: Hello`),
 /// and that space is part of the value.
+#[expect(clippy::exhaustive_structs, reason = "Represents a key/value pair")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Header {
     /// The field name.
@@ -209,26 +215,28 @@ impl Header {
     /// Returns [`Error::MalformedMessage`] if the input has no `:` separator or
     /// contains non-UTF-8 bytes. Returns [`Error::InvalidHeaderName`] or
     /// [`Error::InvalidHeaderValue`] for structurally invalid fields.
-    pub fn parse(input: &[u8]) -> Result<Self> {
-        // Find the first ':' to split name from value.
-        let colon =
-            input
-                .iter()
-                .position(|&b| b == b':')
-                .ok_or_else(|| Error::MalformedMessage {
-                    reason: "header field has no ':' separator".to_owned(),
-                })?;
+    pub fn parse(input: &Bytes) -> Result<Self> {
+        let (name_bytes, remainder) = (
+            terminated(
+                take_until(1.., b':').context(StrContext::Label("Header Name")),
+                b':',
+            ),
+            rest::<&[u8], ContextError<StrContext>>.context(StrContext::Label("Header Value")),
+        )
+            .context(StrContext::Label("Header"))
+            .parse(input)
+            .map_err(|e| Error::MalformedMessage {
+                reason: format!("header field has no ':' separator: {e}"),
+            })?;
 
-        let name_bytes = &input[..colon];
-        let name_str = std::str::from_utf8(name_bytes).map_err(|_| Error::MalformedMessage {
-            reason: "non-UTF-8 header field name".to_owned(),
+        let name_str = std::str::from_utf8(name_bytes).map_err(|e| Error::MalformedMessage {
+            reason: format!("non-UTF-8 header field name: {e}"),
         })?;
         let name = HeaderName::new(name_str)?;
 
         // Value is everything after ':' up to (but not including) the final CRLF.
-        let value_bytes = &input[colon + 1..];
-        let value_str = std::str::from_utf8(value_bytes).map_err(|_| Error::MalformedMessage {
-            reason: "non-UTF-8 header field value".to_owned(),
+        let value_str = std::str::from_utf8(remainder).map_err(|e| Error::MalformedMessage {
+            reason: format!("non-UTF-8 header field value: {e}"),
         })?;
         // Strip exactly the trailing CRLF (folds inside are preserved).
         let value_str = value_str.strip_suffix("\r\n").unwrap_or(value_str);
@@ -308,14 +316,14 @@ impl Headers {
     ///
     /// Returns [`Error::MalformedMessage`] if the header section is
     /// syntactically invalid.
-    pub fn parse(input: &[u8]) -> Result<(Self, &[u8])> {
+    pub fn parse(input: &Bytes) -> Result<(Self, Bytes)> {
         let mut headers = Self::new();
         let mut pos = 0;
 
         loop {
             // Blank line (CRLF with nothing before it) marks end of headers.
             if input[pos..].starts_with(b"\r\n") {
-                return Ok((headers, &input[pos + 2..]));
+                return Ok((headers, input.slice(pos + 2..)));
             }
             if pos >= input.len() {
                 return Err(Error::MalformedMessage {
@@ -325,7 +333,7 @@ impl Headers {
 
             let header_start = pos;
             let header_end = find_header_end(input, pos)?;
-            let header = Header::parse(&input[header_start..header_end])?;
+            let header = Header::parse(&input.slice(header_start..header_end))?;
             headers.push(header);
             pos = header_end;
         }
@@ -385,25 +393,25 @@ mod rfc5322_header_name {
     /// RFC 5322 §2.2: colon is not allowed in field name.
     #[test]
     fn reject_colon() {
-        assert!(HeaderName::new("Sub:ject").is_err());
+        HeaderName::new("Sub:ject").expect_err("Header contains a colon");
     }
 
     /// RFC 5322 §2.2: space (char 32) is below the ftext floor.
     #[test]
     fn reject_space() {
-        assert!(HeaderName::new("Sub ject").is_err());
+        HeaderName::new("Sub ject").expect_err("Header contains a space");
     }
 
     /// RFC 5322 §2.2: DEL (char 127) is above the ftext ceiling.
     #[test]
     fn reject_del() {
-        assert!(HeaderName::new("Sub\x7fject").is_err());
+        HeaderName::new("Sub\x7fject").expect_err("Header contains DEL character");
     }
 
     /// RFC 5322 §2.2: empty string is not a valid field name.
     #[test]
     fn reject_empty() {
-        assert!(HeaderName::new("").is_err());
+        HeaderName::new("").expect_err("Header name cannot be empty");
     }
 
     /// RFC 5322 §2.2: field names are case-insensitive.
@@ -447,19 +455,19 @@ mod rfc5322_header_value {
     /// RFC 5322 §2.2: bare CR is not allowed.
     #[test]
     fn reject_bare_cr() {
-        assert!(HeaderValue::new(" val\rue").is_err());
+        HeaderValue::new(" val\rue").expect_err("bare CR");
     }
 
     /// RFC 5322 §2.2: bare LF is not allowed.
     #[test]
     fn reject_bare_lf() {
-        assert!(HeaderValue::new(" val\nue").is_err());
+        HeaderValue::new(" val\nue").expect_err("bare LF");
     }
 
     /// RFC 5322 §2.2: `CRLF` not followed by WSP is rejected.
     #[test]
     fn reject_crlf_without_wsp() {
-        assert!(HeaderValue::new(" val\r\nue").is_err());
+        HeaderValue::new(" val\r\nue").expect_err("CRLF without WSP");
     }
 
     /// RFC 5322 §2.2.3: unfold removes `CRLF` before SP, keeping the SP.
@@ -491,7 +499,7 @@ mod rfc5322_header_parse {
     /// RFC 5322 §2.2: parse a simple non-folded header field.
     #[test]
     fn parse_simple() {
-        let h = Header::parse(b"Subject: Hello\r\n").expect("simple header");
+        let h = Header::parse(&Bytes::from_static(b"Subject: Hello\r\n")).expect("simple header");
         assert_eq!(h.name.as_str(), "Subject");
         assert_eq!(h.value.as_str(), " Hello");
     }
@@ -499,7 +507,8 @@ mod rfc5322_header_parse {
     /// RFC 5322 §2.2.3: parse a folded header field preserving the fold.
     #[test]
     fn parse_folded() {
-        let h = Header::parse(b"Subject: Hello\r\n world\r\n").expect("folded header");
+        let h = Header::parse(&Bytes::from_static(b"Subject: Hello\r\n world\r\n"))
+            .expect("folded header");
         assert_eq!(h.name.as_str(), "Subject");
         assert!(h.value.as_str().contains("\r\n"));
         assert_eq!(h.value.unfold(), " Hello world");
@@ -509,14 +518,15 @@ mod rfc5322_header_parse {
     #[test]
     fn wire_round_trip() {
         let original = "Subject: Hello\r\n";
-        let h = Header::parse(original.as_bytes()).expect("valid header");
+        let h = Header::parse(&Bytes::from_static(original.as_bytes())).expect("valid header");
         assert_eq!(h.to_wire(), original);
     }
 
     /// RFC 5322 §2.2: leading space after colon is part of value.
     #[test]
     fn leading_space_in_value() {
-        let h = Header::parse(b"From: alice@example.com\r\n").expect("From header");
+        let h = Header::parse(&Bytes::from_static(b"From: alice@example.com\r\n"))
+            .expect("From header");
         assert_eq!(h.value.as_str(), " alice@example.com");
     }
 }
@@ -528,26 +538,27 @@ mod rfc5322_headers_parse {
     /// RFC 5322 §2.1: headers section terminated by blank line (`CRLF CRLF`).
     #[test]
     fn parse_basic() {
-        let input = b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nBody here";
-        let (headers, body) = Headers::parse(input).expect("basic headers");
+        let input =
+            Bytes::from_static(b"From: alice@example.com\r\nTo: bob@example.com\r\n\r\nBody here");
+        let (headers, body) = Headers::parse(&input).expect("basic headers");
         assert_eq!(headers.len(), 2);
-        assert_eq!(body, b"Body here");
+        assert_eq!(&*body, b"Body here");
     }
 
     /// RFC 5322 §2.1: empty header section (blank line only) is valid.
     #[test]
     fn parse_empty_headers() {
-        let input = b"\r\nBody";
-        let (headers, body) = Headers::parse(input).expect("empty header section");
+        let input = Bytes::from_static(b"\r\nBody");
+        let (headers, body) = Headers::parse(&input).expect("empty header section");
         assert_eq!(headers.len(), 0);
-        assert_eq!(body, b"Body");
+        assert_eq!(&*body, b"Body");
     }
 
     /// RFC 5322 §2.2.3: folded header is parsed as a single field.
     #[test]
     fn parse_folded_header() {
-        let input = b"Subject: Hello\r\n world\r\n\r\n";
-        let (headers, _) = Headers::parse(input).expect("folded header section");
+        let input = Bytes::from_static(b"Subject: Hello\r\n world\r\n\r\n");
+        let (headers, _) = Headers::parse(&input).expect("folded header section");
         assert_eq!(headers.len(), 1);
         assert_eq!(
             headers.iter().next().expect("one header").name.as_str(),
@@ -558,8 +569,8 @@ mod rfc5322_headers_parse {
     /// RFC 6376 §5.4.2: insertion order is preserved (top to bottom).
     #[test]
     fn insertion_order_preserved() {
-        let input = b"From: a\r\nReceived: x\r\nReceived: y\r\n\r\n";
-        let (headers, _) = Headers::parse(input).expect("headers with duplicates");
+        let input = Bytes::from_static(b"From: a\r\nReceived: x\r\nReceived: y\r\n\r\n");
+        let (headers, _) = Headers::parse(&input).expect("headers with duplicates");
         let name = HeaderName::new("Received").expect("valid header name");
         let received: Vec<_> = headers.get_all(&name).map(|h| h.value.as_str()).collect();
         assert_eq!(received, [" x", " y"]);
@@ -568,8 +579,8 @@ mod rfc5322_headers_parse {
     /// RFC 6376 §5.4.2: `get_last` returns the bottommost occurrence.
     #[test]
     fn get_last_bottommost() {
-        let input = b"From: first\r\nFrom: second\r\n\r\n";
-        let (headers, _) = Headers::parse(input).expect("duplicate From headers");
+        let input = Bytes::from_static(b"From: first\r\nFrom: second\r\n\r\n");
+        let (headers, _) = Headers::parse(&input).expect("duplicate From headers");
         let name = HeaderName::new("From").expect("valid header name");
         let last = headers.get_last(&name).expect("at least one From header");
         assert_eq!(last.value.as_str(), " second");
@@ -578,15 +589,15 @@ mod rfc5322_headers_parse {
     /// RFC 5322 §2.1: missing blank-line terminator is an error.
     #[test]
     fn reject_missing_terminator() {
-        let result = Headers::parse(b"From: alice@example.com\r\n");
-        assert!(result.is_err());
+        let result = Headers::parse(&Bytes::from_static(b"From: alice@example.com\r\n"));
+        result.expect_err("missing blank line terminator");
     }
 
     /// Body bytes after the blank line are returned unmodified.
     #[test]
     fn body_returned_correctly() {
-        let input = b"From: a\r\n\r\nHello\r\nWorld\r\n";
-        let (_, body) = Headers::parse(input).expect("valid headers");
-        assert_eq!(body, b"Hello\r\nWorld\r\n");
+        let input = Bytes::from_static(b"From: a\r\n\r\nHello\r\nWorld\r\n");
+        let (_, body) = Headers::parse(&input).expect("valid headers");
+        assert_eq!(&*body, b"Hello\r\nWorld\r\n");
     }
 }

--- a/crates/email-primitives/src/lib.rs
+++ b/crates/email-primitives/src/lib.rs
@@ -47,8 +47,13 @@ pub mod address;
 pub mod error;
 pub mod header;
 pub mod message;
+pub mod quotes;
 
-pub use address::{Domain, EmailAddress, LocalPart, NullPath, ReversePath};
+pub use address::EmailAddress;
+pub use address::domain::Domain;
+pub use address::local_part::LocalPart;
+pub use address::owned_reverse_path::OwnedReversePath;
+pub use address::reverse_path::ReversePath;
 pub use error::Error;
 pub use header::{Header, HeaderName, HeaderValue, Headers};
 pub use message::{Message, MessageBody};

--- a/crates/email-primitives/src/message.rs
+++ b/crates/email-primitives/src/message.rs
@@ -35,6 +35,10 @@ use crate::{Headers, Result};
 /// Headers are parsed into the [`Headers`] structure; the body is kept as raw
 /// bytes to avoid unnecessary copies and to preserve exact byte content for
 /// hashing.
+#[expect(
+    clippy::exhaustive_structs,
+    reason = "RFC 5322 provides for only two parts to a message"
+)]
 #[derive(Debug, Clone)]
 pub struct Message {
     /// The parsed header fields in original wire order.
@@ -63,22 +67,9 @@ impl Message {
     /// Returns an error if the header section is malformed, or if the
     /// header/body separator is absent.
     pub fn parse(input: &Bytes) -> Result<Self> {
-        // RFC 5322 §2.1: the first blank line (CRLF CRLF) separates headers
-        // from the body. windows(4) finds it; we pass everything up to and
-        // including that separator to Headers::parse.
-        let sep = input
-            .windows(4)
-            .position(|w| w == b"\r\n\r\n")
-            .ok_or_else(|| crate::Error::MalformedMessage {
-                reason: "missing header/body separator (CRLF CRLF)".to_owned(),
-            })?;
-
         // Headers::parse expects the blank line as its terminator.
-        let (headers, leftover) = Headers::parse(&input[..sep + 4])?;
-        debug_assert!(leftover.is_empty(), "Headers::parse left unexpected bytes");
+        let (headers, body) = Headers::parse(input)?;
 
-        // Body is everything after CRLF CRLF — zero-copy slice of the input.
-        let body = input.slice(sep + 4..);
         Ok(Self {
             headers,
             body: MessageBody::new(body),
@@ -221,7 +212,7 @@ mod rfc5322_message {
     #[test]
     fn reject_no_separator() {
         let input = Bytes::from_static(b"From: a@b.com\r\nNo separator here");
-        assert!(Message::parse(&input).is_err());
+        Message::parse(&input).expect_err("missing header/body separator");
     }
 
     /// Body bytes are a zero-copy slice of the input `Bytes`.

--- a/crates/email-primitives/src/quotes.rs
+++ b/crates/email-primitives/src/quotes.rs
@@ -1,0 +1,305 @@
+//! Validates quoted or delimited sequences in iterators.
+//!
+//! Provides [`IterableQuoted`] to check if elements form a properly
+//! delimited sequence (e.g., `"text"` or `<value>`).
+//!
+//! ```
+//! use email_primitives::quotes::IterableQuoted;
+//!
+//! let data = vec!['"', 'h', 'e', 'l', 'l', 'o', '"'];
+//! let is_quoted = data.into_iter().all_quoted(
+//!     |c| *c == '"',
+//!     |c| *c != '"',
+//!     |c| *c == '"',
+//! );
+//! assert!(is_quoted);
+//! ```
+
+/// Check if iterator elements form a valid delimited sequence.
+///
+/// Validates sequences with opening, inner, and closing predicates.
+/// Requires at least two elements. Returns `false` for empty or single-element iterators.
+pub trait IterableQuoted<T> {
+    /// Checks if all elements form a properly delimited sequence.
+    ///
+    /// Returns `true` if first satisfies `open`, all middle elements satisfy `inner`,
+    /// and last satisfies `end`. Requires at least two elements.
+    ///
+    /// ```
+    /// use email_primitives::quotes::IterableQuoted;
+    ///
+    /// let valid = vec!['"', 'a', 'b', '"'];
+    /// assert!(valid.into_iter().all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"'));
+    ///
+    /// let empty: Vec<char> = vec![];
+    /// assert!(!empty.into_iter().all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"'));
+    /// ```
+    fn all_quoted<O: Fn(&T) -> bool, I: Fn(&T) -> bool, E: Fn(&T) -> bool>(
+        self,
+        open: O,
+        inner: I,
+        end: E,
+    ) -> bool;
+
+    /// Checks if all elements match their respective predicates, including boundaries.
+    ///
+    /// Tests the first element against `open`, all elements (including first and last)
+    /// against `inner`, and the last element against `end`. Returns `true` for empty
+    /// iterators (succeeds unless an element exists and fails a test).
+    ///
+    /// # Differences from `all_quoted`
+    ///
+    /// Unlike `all_quoted`, which only checks `inner` on middle elements, this method
+    /// applies the `inner` predicate to all elements including the opening and closing
+    /// elements.
+    ///
+    /// ```
+    /// use email_primitives::quotes::IterableQuoted;
+    ///
+    /// let valid = vec!['<', 'a', 'b', '>'];
+    /// assert!(valid.into_iter().all_matching(
+    ///     |c| *c == '<',
+    ///     |c| *c != '"',
+    ///     |c| *c == '>'
+    /// ));
+    ///
+    /// let empty: Vec<char> = vec![];
+    /// assert!(empty.into_iter().all_matching(|c| *c == '<', |c| *c != '"', |c| *c == '>'));
+    /// ```
+    fn all_matching<O: Fn(&T) -> bool, I: Fn(&T) -> bool, E: Fn(&T) -> bool>(
+        self,
+        open: O,
+        inner: I,
+        end: E,
+    ) -> bool;
+}
+
+impl<T, Iter: Iterator<Item = T>> IterableQuoted<T> for Iter {
+    fn all_quoted<O: Fn(&T) -> bool, I: Fn(&T) -> bool, E: Fn(&T) -> bool>(
+        mut self,
+        open: O,
+        inner: I,
+        end: E,
+    ) -> bool {
+        if let Some(first) = self.next() {
+            if !open(&first) {
+                return false;
+            }
+            if let Some(mut cur) = self.next() {
+                loop {
+                    if let Some(next) = self.next() {
+                        if !inner(&cur) {
+                            return false;
+                        }
+                        cur = next;
+                    } else {
+                        return end(&cur);
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn all_matching<O: Fn(&T) -> bool, I: Fn(&T) -> bool, E: Fn(&T) -> bool>(
+        mut self,
+        open: O,
+        inner: I,
+        end: E,
+    ) -> bool {
+        if let Some(mut cur) = self.next() {
+            if !open(&cur) {
+                return false;
+            }
+            loop {
+                if !inner(&cur) {
+                    return false;
+                }
+                if let Some(next) = self.next() {
+                    cur = next;
+                } else {
+                    return end(&cur);
+                }
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_quoted_empty_iterator() {
+        let data: Vec<char> = vec![];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_quoted_single_quote() {
+        let data = vec!['"'];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_quoted_valid_quoted_string() {
+        let data = vec!['"', 'h', 'e', 'l', 'l', 'o', '"'];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_quoted_invalid_opening() {
+        let data = vec!['h', 'e', 'l', 'l', 'o', '"'];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_quoted_invalid_ending() {
+        let data = vec!['"', 'h', 'e', 'l', 'l', 'o'];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_quoted_invalid_inner_character() {
+        let data = vec!['"', 'h', 'e', '"', 'l', 'o', '"'];
+        let result = data
+            .into_iter()
+            .all_quoted(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_quoted_with_brackets() {
+        let data = vec!['<', 'a', 'b', 'c', '>'];
+        let result =
+            data.into_iter()
+                .all_quoted(|c| *c == '<', |c| *c != '<' && *c != '>', |c| *c == '>');
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_quoted_numbers() {
+        let data = vec![0, 1, 2, 3, 4];
+        let result = data
+            .into_iter()
+            .all_quoted(|n| *n == 0, |n| *n > 0 && *n < 4, |n| *n == 4);
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_quoted_numbers_invalid() {
+        let data = vec![0, 1, 2, 5, 4];
+        let result = data
+            .into_iter()
+            .all_quoted(|n| *n == 0, |n| *n > 0 && *n < 4, |n| *n == 4);
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_empty_iterator() {
+        let data: Vec<char> = vec![];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_matching_single_element() {
+        let data = vec!['"'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '"', |c| *c == '"', |c| *c == '"');
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_matching_single_element_invalid_open() {
+        let data = vec!['x'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '"', |_| true, |c| *c == 'x');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_single_element_invalid_inner() {
+        let data = vec!['"'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '"', |c| *c != '"', |c| *c == '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_single_element_invalid_end() {
+        let data = vec!['"'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '"', |c| *c == '"', |c| *c != '"');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_valid_sequence() {
+        let data = vec!['<', 'a', 'b', '>'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '<', |c| *c != '"', |c| *c == '>');
+        assert!(result);
+    }
+
+    #[test]
+    fn test_all_matching_invalid_opening() {
+        let data = vec!['x', 'a', 'b', '>'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '<', |c| *c != '"', |c| *c == '>');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_invalid_inner() {
+        let data = vec!['<', 'a', '"', '>'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '<', |c| *c != '"', |c| *c == '>');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_invalid_ending() {
+        let data = vec!['<', 'a', 'b', 'x'];
+        let result = data
+            .into_iter()
+            .all_matching(|c| *c == '<', |c| *c != '"', |c| *c == '>');
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_all_matching_inner_checks_boundaries() {
+        let data = vec!['<', 'a', 'b', '>'];
+        let result = data.into_iter().all_matching(
+            |c| *c == '<',
+            |c| *c == '<' || *c == '>' || (*c >= 'a' && *c <= 'z'),
+            |c| *c == '>',
+        );
+        assert!(result);
+    }
+}

--- a/crates/lmtp/src/command.rs
+++ b/crates/lmtp/src/command.rs
@@ -23,11 +23,13 @@
 //! address (RFC 5321 section 4.1.2). Parameters are key=value pairs or bare
 //! keywords. Recognised parameters include `SIZE=<n>` and `BODY=8BITMIME`.
 
-use email_primitives::{Domain, EmailAddress, NullPath};
-
 use crate::Result;
+use email_primitives::EmailAddress;
+use email_primitives::address::Domain;
+use email_primitives::address::OwnedReversePath;
 
 /// A parsed LMTP client command.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
     /// `LHLO <domain>`
@@ -50,7 +52,7 @@ pub enum Command {
     /// - `BODY=7BIT | 8BITMIME | BINARYMIME` – message body encoding.
     Mail {
         /// The sender's reverse-path.
-        from: NullPath,
+        from: OwnedReversePath,
         /// Optional ESMTP mail parameters.
         parameters: Vec<MailParam>,
     },
@@ -136,6 +138,7 @@ impl std::fmt::Display for Command {
 }
 
 /// An ESMTP parameter for the `MAIL FROM` command.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MailParam {
     /// `SIZE=<n>` – estimated message size in octets (RFC 1870).
@@ -150,6 +153,7 @@ pub enum MailParam {
 }
 
 /// An ESMTP parameter for the `RCPT TO` command.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RcptParam {
     /// An unrecognised parameter preserved verbatim.

--- a/crates/lmtp/src/lib.rs
+++ b/crates/lmtp/src/lib.rs
@@ -79,6 +79,7 @@ pub use session::Session;
 use thiserror::Error;
 
 /// Errors that can arise in LMTP processing.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum Error {
     /// An I/O error on the underlying transport.

--- a/crates/lmtp/src/response.rs
+++ b/crates/lmtp/src/response.rs
@@ -132,6 +132,7 @@ impl std::fmt::Display for ReplyCode {
 /// <code>-<line2>\r\n
 /// <code> <lastline>\r\n
 /// ```
+#[expect(clippy::exhaustive_structs, reason = "Exhaustive by RFC")]
 #[derive(Debug, Clone)]
 pub struct Reply {
     /// The reply code.
@@ -143,7 +144,7 @@ pub struct Reply {
 impl Reply {
     /// Construct a single-line reply.
     #[must_use]
-    pub fn new(code: ReplyCode, text: impl Into<String>) -> Self {
+    pub fn new<T: Into<String>>(code: ReplyCode, text: T) -> Self {
         Self {
             code,
             lines: vec![text.into()],
@@ -164,6 +165,7 @@ impl Reply {
         let mut out = String::new();
         for (i, line) in self.lines.iter().enumerate() {
             let sep = if i + 1 == self.lines.len() { ' ' } else { '-' };
+            #[expect(clippy::expect_used, reason = "String::write is infallible")]
             write!(out, "{}{}{}\r\n", self.code, sep, line)
                 .expect("writing to String is infallible");
         }

--- a/crates/lmtp/src/server.rs
+++ b/crates/lmtp/src/server.rs
@@ -38,6 +38,7 @@ use crate::Result;
 use crate::session::MessageHandler;
 
 /// Configuration for the LMTP server.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// The hostname to announce in the `220` greeting and `221` closing.

--- a/crates/lmtp/src/session.rs
+++ b/crates/lmtp/src/session.rs
@@ -22,13 +22,14 @@
 //! [`MessageHandler::handle`], which returns one [`crate::Reply`] per
 //! recipient. The session then sends those replies in order.
 
-use email_primitives::{EmailAddress, Message, NullPath};
-
 use crate::{Result, response::Reply};
+use email_primitives::address::OwnedReversePath;
+use email_primitives::{EmailAddress, Message};
 
 /// The current state of an LMTP session.
+#[expect(dead_code, reason = "stub: used by handle_command() once implemented")]
 #[derive(Debug)]
-pub enum SessionState {
+pub(crate) enum SessionState {
     /// TCP connection established; `220` greeting sent; waiting for `LHLO`.
     Connected,
 
@@ -43,7 +44,7 @@ pub enum SessionState {
         /// The domain from `LHLO`.
         client_domain: email_primitives::Domain,
         /// The envelope sender.
-        sender: NullPath,
+        sender: OwnedReversePath,
         /// Parameters from the `MAIL FROM` command.
         mail_params: Vec<crate::command::MailParam>,
     },
@@ -53,7 +54,7 @@ pub enum SessionState {
         /// The domain from `LHLO`.
         client_domain: email_primitives::Domain,
         /// The envelope sender.
-        sender: NullPath,
+        sender: OwnedReversePath,
         /// Accepted recipients, in the order they were received.
         ///
         /// LMTP requires that per-recipient DATA responses are sent in the
@@ -66,7 +67,7 @@ pub enum SessionState {
         /// The domain from `LHLO`.
         client_domain: email_primitives::Domain,
         /// The envelope sender.
-        sender: NullPath,
+        sender: OwnedReversePath,
         /// The recipients awaiting per-message responses.
         recipients: Vec<EmailAddress>,
     },
@@ -76,17 +77,19 @@ pub enum SessionState {
 }
 
 /// Envelope information for a received message.
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct Envelope {
     /// The `LHLO` domain, identifying the connecting client.
     pub client_domain: email_primitives::Domain,
     /// The `MAIL FROM` reverse-path.
-    pub sender: NullPath,
+    pub sender: OwnedReversePath,
     /// The accepted `RCPT TO` addresses, in order.
     pub recipients: Vec<EmailAddress>,
 }
 
 /// Outcome of processing a single recipient's delivery.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct RecipientResult {
     /// The recipient address.
@@ -126,6 +129,8 @@ pub trait MessageHandler: Send + Sync {
 ///
 /// The generic parameter `H` is the [`MessageHandler`] that processes received
 /// messages. The session is created per TCP/Unix connection.
+#[non_exhaustive]
+#[derive(Debug)]
 pub struct Session<H: MessageHandler> {
     /// The server's hostname, used in greeting and `QUIT` responses.
     pub hostname: String,
@@ -137,7 +142,7 @@ pub struct Session<H: MessageHandler> {
 
 impl<H: MessageHandler> Session<H> {
     /// Construct a new session in the [`SessionState::Connected`] state.
-    pub fn new(hostname: impl Into<String>, handler: H) -> Self {
+    pub fn new<S: Into<String>>(hostname: S, handler: H) -> Self {
         Self {
             hostname: hostname.into(),
             state: SessionState::Connected,

--- a/crates/service/src/config/arc.rs
+++ b/crates/service/src/config/arc.rs
@@ -1,0 +1,29 @@
+use super::default_signed_headers;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// ARC signing configuration (inbound mode).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ArcConfig {
+    /// `d=` domain for ARC-Seal and ARC-Message-Signature.
+    pub domain: String,
+
+    /// `s=` selector.
+    pub selector: String,
+
+    /// Path to the PEM-encoded private key file.
+    ///
+    /// Accepted formats: PKCS#8 RSA or Ed25519. Ed25519 is recommended.
+    pub key_file: PathBuf,
+
+    /// The authentication service identifier to use in
+    /// `ARC-Authentication-Results`. Typically the MX hostname.
+    pub authserv_id: String,
+
+    /// Header fields to include in the ARC-Message-Signature `h=` list
+    /// beyond the required `ARC-Authentication-Results` and `From:`.
+    ///
+    /// Default matches the DKIM recommended list.
+    #[serde(default = "default_signed_headers")]
+    pub signed_headers: Vec<String>,
+}

--- a/crates/service/src/config/dkim_signing.rs
+++ b/crates/service/src/config/dkim_signing.rs
@@ -1,0 +1,26 @@
+use super::default_signed_headers;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// DKIM signing configuration for one domain (outbound mode).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct DkimSigningConfig {
+    /// `d=` domain.
+    pub domain: String,
+
+    /// `s=` selector.
+    pub selector: String,
+
+    /// Path to the PEM-encoded private key file.
+    pub key_file: PathBuf,
+
+    /// Header fields to sign.
+    #[serde(default = "default_signed_headers")]
+    pub signed_headers: Vec<String>,
+
+    /// Signature expiry in seconds from the time of signing.
+    ///
+    /// `None` means no expiry. Recommended: 604800 (7 days).
+    #[serde(default)]
+    pub expiry_secs: Option<u64>,
+}

--- a/crates/service/src/config/downstream.rs
+++ b/crates/service/src/config/downstream.rs
@@ -1,0 +1,20 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Where to deliver processed mail.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub(crate) enum DownstreamConfig {
+    /// Deliver to a Unix-socket LMTP server (e.g. Dovecot).
+    UnixSocket {
+        /// Path to the downstream LMTP socket.
+        socket: PathBuf,
+    },
+    /// Deliver to a TCP LMTP or SMTP server.
+    Tcp {
+        /// Hostname of the downstream server.
+        host: String,
+        /// Port (25 for SMTP, 24 for LMTP over TCP).
+        port: u16,
+    },
+}

--- a/crates/service/src/config/mod.rs
+++ b/crates/service/src/config/mod.rs
@@ -40,13 +40,22 @@
 //! key_file = "/etc/lmtp-dkim/dkim.pem"
 //! ```
 
+mod arc;
+mod dkim_signing;
+mod downstream;
+mod server_settings;
+
 use std::path::{Path, PathBuf};
 
+use arc::ArcConfig;
+use dkim_signing::DkimSigningConfig;
+use downstream::DownstreamConfig;
 use serde::{Deserialize, Serialize};
+use server_settings::ServerSettings;
 
 /// Top-level configuration.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct Config {
+pub(crate) struct Config {
     /// Operating mode.
     pub mode: Mode,
 
@@ -73,7 +82,7 @@ pub struct Config {
 /// Operating mode of the service.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub enum Mode {
+pub(crate) enum Mode {
     /// Accept mail from the Internet, validate, ARC-seal, and forward.
     Inbound,
     /// Accept mail from users, DKIM-sign, and forward.
@@ -83,7 +92,7 @@ pub enum Mode {
 /// How and where to listen for incoming LMTP connections.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
-pub enum ListenConfig {
+pub(crate) enum ListenConfig {
     /// Listen on a Unix domain socket.
     UnixSocket {
         /// Path to the socket file.
@@ -101,100 +110,42 @@ pub enum ListenConfig {
     },
 }
 
+impl Config {
+    /// Load configuration from a TOML file.
+    ///
+    /// If `path` is `None`, tries `LMTP_DKIM_CONFIG` env var, then
+    /// `/etc/lmtp-dkim/config.toml`.
+    pub(crate) fn load(path: Option<&Path>) -> anyhow::Result<Self> {
+        let default_path = PathBuf::from("/etc/lmtp-dkim/config.toml");
+        let effective_path = path.unwrap_or(&default_path);
+        let raw = std::fs::read_to_string(effective_path)?;
+        let config: Self = toml::from_str(&raw)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate that required fields for the chosen mode are present.
+    pub(crate) fn validate(&self) -> anyhow::Result<()> {
+        match self.mode {
+            Mode::Inbound => {
+                anyhow::ensure!(
+                    self.arc.is_some(),
+                    "inbound mode requires an [arc] configuration section"
+                );
+            }
+            Mode::Outbound => {
+                anyhow::ensure!(
+                    !self.dkim.is_empty(),
+                    "outbound mode requires at least one [[dkim]] configuration section"
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
 const fn default_socket_mode() -> u32 {
     0o600
-}
-
-/// Where to deliver processed mail.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum DownstreamConfig {
-    /// Deliver to a Unix-socket LMTP server (e.g. Dovecot).
-    UnixSocket {
-        /// Path to the downstream LMTP socket.
-        socket: PathBuf,
-    },
-    /// Deliver to a TCP LMTP or SMTP server.
-    Tcp {
-        /// Hostname of the downstream server.
-        host: String,
-        /// Port (25 for SMTP, 24 for LMTP over TCP).
-        port: u16,
-    },
-}
-
-/// ARC signing configuration (inbound mode).
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ArcConfig {
-    /// `d=` domain for ARC-Seal and ARC-Message-Signature.
-    pub domain: String,
-
-    /// `s=` selector.
-    pub selector: String,
-
-    /// Path to the PEM-encoded private key file.
-    ///
-    /// Accepted formats: PKCS#8 RSA or Ed25519. Ed25519 is recommended.
-    pub key_file: PathBuf,
-
-    /// The authentication service identifier to use in
-    /// `ARC-Authentication-Results`. Typically the MX hostname.
-    pub authserv_id: String,
-
-    /// Header fields to include in the ARC-Message-Signature `h=` list
-    /// beyond the required `ARC-Authentication-Results` and `From:`.
-    ///
-    /// Default matches the DKIM recommended list.
-    #[serde(default = "default_signed_headers")]
-    pub signed_headers: Vec<String>,
-}
-
-/// DKIM signing configuration for one domain (outbound mode).
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct DkimSigningConfig {
-    /// `d=` domain.
-    pub domain: String,
-
-    /// `s=` selector.
-    pub selector: String,
-
-    /// Path to the PEM-encoded private key file.
-    pub key_file: PathBuf,
-
-    /// Header fields to sign.
-    #[serde(default = "default_signed_headers")]
-    pub signed_headers: Vec<String>,
-
-    /// Signature expiry in seconds from the time of signing.
-    ///
-    /// `None` means no expiry. Recommended: 604800 (7 days).
-    #[serde(default)]
-    pub expiry_secs: Option<u64>,
-}
-
-/// Miscellaneous server settings.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ServerSettings {
-    /// Server hostname to announce in LMTP `220` greetings.
-    ///
-    /// Defaults to the system hostname.
-    #[serde(default)]
-    pub hostname: Option<String>,
-
-    /// Maximum accepted message size in bytes.
-    ///
-    /// Defaults to 50 MiB.
-    #[serde(default = "default_max_message_size")]
-    pub max_message_size: usize,
-}
-
-impl Default for ServerSettings {
-    fn default() -> Self {
-        Self {
-            hostname: None,
-            max_message_size: default_max_message_size(),
-        }
-    }
 }
 
 const fn default_max_message_size() -> usize {
@@ -215,38 +166,4 @@ fn default_signed_headers() -> Vec<String> {
         "content-type".into(),
         "mime-version".into(),
     ]
-}
-
-impl Config {
-    /// Load configuration from a TOML file.
-    ///
-    /// If `path` is `None`, tries `LMTP_DKIM_CONFIG` env var, then
-    /// `/etc/lmtp-dkim/config.toml`.
-    pub fn load(path: Option<&Path>) -> anyhow::Result<Self> {
-        let default_path = PathBuf::from("/etc/lmtp-dkim/config.toml");
-        let effective_path = path.unwrap_or(&default_path);
-        let raw = std::fs::read_to_string(effective_path)?;
-        let config: Self = toml::from_str(&raw)?;
-        config.validate()?;
-        Ok(config)
-    }
-
-    /// Validate that required fields for the chosen mode are present.
-    pub fn validate(&self) -> anyhow::Result<()> {
-        match self.mode {
-            Mode::Inbound => {
-                anyhow::ensure!(
-                    self.arc.is_some(),
-                    "inbound mode requires an [arc] configuration section"
-                );
-            }
-            Mode::Outbound => {
-                anyhow::ensure!(
-                    !self.dkim.is_empty(),
-                    "outbound mode requires at least one [[dkim]] configuration section"
-                );
-            }
-        }
-        Ok(())
-    }
 }

--- a/crates/service/src/config/server_settings.rs
+++ b/crates/service/src/config/server_settings.rs
@@ -1,0 +1,27 @@
+use super::default_max_message_size;
+use serde::{Deserialize, Serialize};
+
+/// Miscellaneous server settings.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct ServerSettings {
+    /// Server hostname to announce in LMTP `220` greetings.
+    ///
+    /// Defaults to the system hostname.
+    #[serde(default)]
+    pub hostname: Option<String>,
+
+    /// Maximum accepted message size in bytes.
+    ///
+    /// Defaults to 50 MiB.
+    #[serde(default = "default_max_message_size")]
+    pub max_message_size: usize,
+}
+
+impl Default for ServerSettings {
+    fn default() -> Self {
+        Self {
+            hostname: None,
+            max_message_size: default_max_message_size(),
+        }
+    }
+}

--- a/crates/service/src/inbound/downstream.rs
+++ b/crates/service/src/inbound/downstream.rs
@@ -1,0 +1,36 @@
+use email_primitives::Message;
+use lmtp::session::{Envelope, RecipientResult};
+
+/// Client for forwarding messages to the downstream LMTP server.
+///
+/// Initiates an LMTP session (sends LHLO, MAIL FROM, RCPT TO ×N, DATA)
+/// and collects per-recipient responses.
+pub(crate) struct DownstreamClient {
+    // connection pool or address config
+}
+
+impl DownstreamClient {
+    /// Forward a message to the downstream LMTP server.
+    ///
+    /// Returns one [`RecipientResult`] per entry in `envelope.recipients`,
+    /// suitable for passing back to the upstream client.
+    #[expect(
+        dead_code,
+        reason = "stub: called by MessageHandler::handle once implemented"
+    )]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await LMTP connection once implemented"
+    )]
+    async fn deliver(
+        &self,
+        _envelope: &Envelope,
+        _message: &Message,
+    ) -> lmtp::Result<Vec<RecipientResult>> {
+        todo!(
+            "open TCP/Unix connection to downstream; \
+             send LHLO; MAIL FROM; RCPT TO * recipients; DATA; \
+             collect per-recipient 250/4xx/5xx replies; close or cache connection"
+        )
+    }
+}

--- a/crates/service/src/inbound/handler.rs
+++ b/crates/service/src/inbound/handler.rs
@@ -1,0 +1,42 @@
+use crate::inbound::downstream::DownstreamClient;
+use email_primitives::Message;
+use lmtp::session::{Envelope, MessageHandler, RecipientResult};
+use std::sync::Arc as StdArc;
+
+/// LMTP [`MessageHandler`] for the inbound pipeline.
+#[derive(Clone)]
+#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
+pub(crate) struct InboundHandler {
+    inner: StdArc<InboundHandlerInner>,
+}
+
+#[expect(
+    dead_code,
+    reason = "stub: fields used by MessageHandler::handle once implemented"
+)]
+struct InboundHandlerInner {
+    arc_signer: arc::ArcSigner,
+    dkim_verifier: dkim::Verifier,
+    arc_validator: arc::ChainValidator,
+    downstream: DownstreamClient,
+    authserv_id: String,
+}
+
+impl MessageHandler for InboundHandler {
+    async fn handle(
+        &self,
+        envelope: Envelope,
+        message: Message,
+    ) -> lmtp::Result<Vec<RecipientResult>> {
+        let _ = (envelope, message);
+        todo!(
+            "1. dkim_verifier.verify(&message); \
+             2. arc_validator.validate(&message); \
+             3. evaluate SPF (envelope.sender, client IP from LHLO domain); \
+             4. build SealRequest with auth results; \
+             5. arc_signer.seal(&message, chain_result, seal_request); \
+             6. downstream.deliver(envelope, sealed_message); \
+             7. map downstream per-recipient replies to RecipientResult"
+        )
+    }
+}

--- a/crates/service/src/inbound/mod.rs
+++ b/crates/service/src/inbound/mod.rs
@@ -45,15 +45,8 @@
 //! client if adding ARC is required; otherwise the message is forwarded as-is
 //! with a warning log.
 
-use std::sync::Arc as StdArc;
-
-use email_primitives::Message;
-use lmtp::session::{Envelope, MessageHandler, RecipientResult};
-#[expect(
-    unused_imports,
-    reason = "stub: tracing macros used when run() is implemented"
-)]
-use tracing::{error, info, warn};
+mod downstream;
+mod handler;
 
 use crate::config::Config;
 
@@ -65,7 +58,7 @@ use crate::config::Config;
     clippy::unused_async,
     reason = "stub: will await server.serve_* once implemented"
 )]
-pub async fn run(config: Config) -> anyhow::Result<()> {
+pub(crate) async fn run(config: Config) -> anyhow::Result<()> {
     let _ = config;
     todo!(
         "1. load ARC private key from config.arc.key_file; \
@@ -75,80 +68,4 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
          5. bind listener per config.listen; \
          6. Server::new(server_config, handler).serve_*(listener).await"
     )
-}
-
-/// LMTP [`MessageHandler`] for the inbound pipeline.
-#[derive(Clone)]
-#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
-pub struct InboundHandler {
-    inner: StdArc<InboundHandlerInner>,
-}
-
-#[expect(
-    dead_code,
-    reason = "stub: fields used by MessageHandler::handle once implemented"
-)]
-struct InboundHandlerInner {
-    arc_signer: arc::ArcSigner,
-    dkim_verifier: dkim::Verifier,
-    arc_validator: arc::ChainValidator,
-    downstream: DownstreamClient,
-    authserv_id: String,
-}
-
-impl MessageHandler for InboundHandler {
-    async fn handle(
-        &self,
-        envelope: Envelope,
-        message: Message,
-    ) -> lmtp::Result<Vec<RecipientResult>> {
-        let _ = (envelope, message);
-        todo!(
-            "1. dkim_verifier.verify(&message); \
-             2. arc_validator.validate(&message); \
-             3. evaluate SPF (envelope.sender, client IP from LHLO domain); \
-             4. build SealRequest with auth results; \
-             5. arc_signer.seal(&message, chain_result, seal_request); \
-             6. downstream.deliver(envelope, sealed_message); \
-             7. map downstream per-recipient replies to RecipientResult"
-        )
-    }
-}
-
-/// Client for forwarding messages to the downstream LMTP server.
-///
-/// Initiates an LMTP session (sends LHLO, MAIL FROM, RCPT TO ×N, DATA)
-/// and collects per-recipient responses.
-#[expect(
-    dead_code,
-    reason = "stub: constructed in InboundHandlerInner once implemented"
-)]
-struct DownstreamClient {
-    // connection pool or address config
-}
-
-impl DownstreamClient {
-    /// Forward a message to the downstream LMTP server.
-    ///
-    /// Returns one [`RecipientResult`] per entry in `envelope.recipients`,
-    /// suitable for passing back to the upstream client.
-    #[expect(
-        dead_code,
-        reason = "stub: called by MessageHandler::handle once implemented"
-    )]
-    #[expect(
-        clippy::unused_async,
-        reason = "stub: will await LMTP connection once implemented"
-    )]
-    async fn deliver(
-        &self,
-        _envelope: &Envelope,
-        _message: &Message,
-    ) -> lmtp::Result<Vec<RecipientResult>> {
-        todo!(
-            "open TCP/Unix connection to downstream; \
-             send LHLO; MAIL FROM; RCPT TO * recipients; DATA; \
-             collect per-recipient 250/4xx/5xx replies; close or cache connection"
-        )
-    }
 }

--- a/crates/service/src/outbound/downstream.rs
+++ b/crates/service/src/outbound/downstream.rs
@@ -1,0 +1,32 @@
+use email_primitives::Message;
+use lmtp::session::{Envelope, RecipientResult};
+
+/// Client for forwarding signed messages downstream.
+///
+/// Identical in structure to the inbound [`crate::inbound::DownstreamClient`];
+/// consider extracting to a shared module once both modes are implemented.
+pub(crate) struct DownstreamClient {
+    // connection pool or address config
+}
+
+impl DownstreamClient {
+    #[expect(
+        dead_code,
+        reason = "stub: called by MessageHandler::handle once implemented"
+    )]
+    #[expect(
+        clippy::unused_async,
+        reason = "stub: will await LMTP connection once implemented"
+    )]
+    async fn deliver(
+        &self,
+        _envelope: &Envelope,
+        _message: &Message,
+    ) -> lmtp::Result<Vec<RecipientResult>> {
+        todo!(
+            "open TCP/Unix connection to downstream; \
+             LHLO, MAIL FROM, RCPT TO, DATA; \
+             collect per-recipient replies"
+        )
+    }
+}

--- a/crates/service/src/outbound/handler.rs
+++ b/crates/service/src/outbound/handler.rs
@@ -1,0 +1,42 @@
+use crate::outbound::downstream::DownstreamClient;
+use email_primitives::Message;
+use lmtp::session::{Envelope, MessageHandler, RecipientResult};
+use std::collections::HashMap;
+use std::sync::Arc as StdArc;
+
+/// LMTP [`MessageHandler`] for the outbound pipeline.
+#[derive(Clone)]
+#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
+pub(crate) struct OutboundHandler {
+    inner: StdArc<OutboundHandlerInner>,
+}
+
+#[expect(
+    dead_code,
+    reason = "stub: fields used by MessageHandler::handle once implemented"
+)]
+struct OutboundHandlerInner {
+    /// Map from lowercase domain string to configured signer.
+    ///
+    /// Keyed by the `d=` domain as configured in `[[dkim]]`.
+    signers: HashMap<String, dkim::Signer>,
+    downstream: DownstreamClient,
+}
+
+impl MessageHandler for OutboundHandler {
+    async fn handle(
+        &self,
+        envelope: Envelope,
+        message: Message,
+    ) -> lmtp::Result<Vec<RecipientResult>> {
+        let _ = (envelope, message);
+        todo!(
+            "1. extract From: header domain; \
+             2. look up self.inner.signers.get(domain); \
+             3. if found: signer.sign(&message); \
+             4. if not found: warn and use unsigned message; \
+             5. downstream.deliver(envelope, signed_or_original_message); \
+             6. return per-recipient RecipientResult"
+        )
+    }
+}

--- a/crates/service/src/outbound/mod.rs
+++ b/crates/service/src/outbound/mod.rs
@@ -39,16 +39,8 @@
 //! be served by a single instance. Each incoming message is signed with the
 //! key corresponding to its `From:` domain.
 
-use std::collections::HashMap;
-use std::sync::Arc as StdArc;
-
-use email_primitives::Message;
-use lmtp::session::{Envelope, MessageHandler, RecipientResult};
-#[expect(
-    unused_imports,
-    reason = "stub: tracing macros used when run() is implemented"
-)]
-use tracing::{info, warn};
+mod downstream;
+mod handler;
 
 use crate::config::Config;
 
@@ -57,7 +49,7 @@ use crate::config::Config;
     clippy::unused_async,
     reason = "stub: will await server.serve_* once implemented"
 )]
-pub async fn run(config: Config) -> anyhow::Result<()> {
+pub(crate) async fn run(config: Config) -> anyhow::Result<()> {
     let _ = config;
     todo!(
         "1. load DKIM private keys for each config.dkim entry; \
@@ -66,75 +58,4 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
          4. bind listener per config.listen; \
          5. Server::new(server_config, handler).serve_*(listener).await"
     )
-}
-
-/// LMTP [`MessageHandler`] for the outbound pipeline.
-#[derive(Clone)]
-#[expect(dead_code, reason = "stub: constructed in run() once implemented")]
-pub struct OutboundHandler {
-    inner: StdArc<OutboundHandlerInner>,
-}
-
-#[expect(
-    dead_code,
-    reason = "stub: fields used by MessageHandler::handle once implemented"
-)]
-struct OutboundHandlerInner {
-    /// Map from lowercase domain string to configured signer.
-    ///
-    /// Keyed by the `d=` domain as configured in `[[dkim]]`.
-    signers: HashMap<String, dkim::Signer>,
-    downstream: DownstreamClient,
-}
-
-impl MessageHandler for OutboundHandler {
-    async fn handle(
-        &self,
-        envelope: Envelope,
-        message: Message,
-    ) -> lmtp::Result<Vec<RecipientResult>> {
-        let _ = (envelope, message);
-        todo!(
-            "1. extract From: header domain; \
-             2. look up self.inner.signers.get(domain); \
-             3. if found: signer.sign(&message); \
-             4. if not found: warn and use unsigned message; \
-             5. downstream.deliver(envelope, signed_or_original_message); \
-             6. return per-recipient RecipientResult"
-        )
-    }
-}
-
-/// Client for forwarding signed messages downstream.
-///
-/// Identical in structure to the inbound [`crate::inbound::DownstreamClient`];
-/// consider extracting to a shared module once both modes are implemented.
-#[expect(
-    dead_code,
-    reason = "stub: constructed in OutboundHandlerInner once implemented"
-)]
-struct DownstreamClient {
-    // connection pool or address config
-}
-
-impl DownstreamClient {
-    #[expect(
-        dead_code,
-        reason = "stub: called by MessageHandler::handle once implemented"
-    )]
-    #[expect(
-        clippy::unused_async,
-        reason = "stub: will await LMTP connection once implemented"
-    )]
-    async fn deliver(
-        &self,
-        _envelope: &Envelope,
-        _message: &Message,
-    ) -> lmtp::Result<Vec<RecipientResult>> {
-        todo!(
-            "open TCP/Unix connection to downstream; \
-             LHLO, MAIL FROM, RCPT TO, DATA; \
-             collect per-recipient replies"
-        )
-    }
 }


### PR DESCRIPTION
Dependency upgrades:
- winnow 0.6 → 1
- hickory-resolver 0.24 → 0.26
- toml 0.8 → 1

Lint tightening:
- Replace broad clippy::all/nursery groups with explicit lint groups and a curated set of restriction lints (exhaustive_enums, exhaustive_structs, expect_used, panic, etc.)
- Add clippy.toml (allow-expect-in-tests, source-item-ordering)
- Apply #[non_exhaustive] throughout public API types to satisfy the new exhaustive lints; #[expect(exhaustive_*)] where RFC vocabulary demands exhaustiveness (Canonicalization, Reply, etc.)
- Promote unreachable_pub warn → deny; wildcard_imports allow → deny

email-primitives refactor:
- Split address.rs into submodules (domain, local_part, owned_reverse_path, reverse_path) as the file was growing unwieldy
- Rename NullPath → OwnedReversePath for clarity; introduce borrowed ReversePath<'a> counterpart with From<&OwnedReversePath>
- Add quotes::IterableQuoted for boundary-validated iterator sequences, used in validate_label
- Switch Header::parse and Headers::parse to &Bytes to enable zero-copy slicing through the message pipeline; Message::parse simplified as a result
- Error::InvalidAddress now carries an optional source error

Service crate: split config.rs, inbound.rs, outbound.rs into submodule trees (config/{arc,dkim_signing,downstream,server_settings}, inbound/{downstream,handler}, outbound/{downstream,handler})