### PR TITLE
Implement lmtp/session: command parser and state machine (step 3)

### DIFF
--- a/crates/lmtp/src/command.rs
+++ b/crates/lmtp/src/command.rs
@@ -23,7 +23,7 @@
 //! address (RFC 5321 section 4.1.2). Parameters are key=value pairs or bare
 //! keywords. Recognised parameters include `SIZE=<n>` and `BODY=8BITMIME`.
 
-use crate::Result;
+use crate::{Error, Result};
 use email_primitives::EmailAddress;
 use email_primitives::address::Domain;
 use email_primitives::address::OwnedReversePath;
@@ -112,13 +112,49 @@ impl Command {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::BadCommand`] if the line cannot be parsed as a
+    /// Returns [`Error::BadCommand`] if the line cannot be parsed as a
     /// valid LMTP command.
-    pub fn parse(_line: &str) -> Result<Self> {
-        todo!(
-            "winnow parser: case-insensitive verb match, then parse arguments; \
-             reject HELO/EHLO with 500 (RFC 2033 §4.1)"
-        )
+    pub fn parse(line: &str) -> Result<Self> {
+        let bad = || Error::BadCommand(line.to_owned());
+
+        // Split verb from rest; verb is case-insensitive (RFC 5321 §2.4).
+        let (verb, rest) = match line.find(|c: char| c.is_ascii_whitespace()) {
+            Some(i) => (&line[..i], line[i + 1..].trim_start()),
+            None => (line, ""),
+        };
+
+        match verb.to_ascii_uppercase().as_str() {
+            "LHLO" => {
+                let client_domain = Domain::parse(rest).map_err(|_domain_err| bad())?;
+                Ok(Self::Lhlo { client_domain })
+            }
+            "MAIL" => {
+                // RFC 5321 §4.1.1.2: MAIL FROM:<reverse-path> [SP params]
+                let rest = rest.strip_prefix_ci("FROM:").ok_or_else(bad)?;
+                let (path_str, param_str) = split_path(rest);
+                let from = parse_reverse_path(path_str).ok_or_else(bad)?;
+                let parameters = parse_mail_params(param_str);
+                Ok(Self::Mail { from, parameters })
+            }
+            "RCPT" => {
+                // RFC 5321 §4.1.1.3: RCPT TO:<forward-path> [SP params]
+                let rest = rest.strip_prefix_ci("TO:").ok_or_else(bad)?;
+                let (path_str, param_str) = split_path(rest);
+                let addr_str = path_str.trim_matches(|c| c == '<' || c == '>');
+                let to = EmailAddress::parse(addr_str).map_err(|_addr_err| bad())?;
+                let parameters = parse_rcpt_params(param_str);
+                Ok(Self::Rcpt { to, parameters })
+            }
+            "DATA" => Ok(Self::Data),
+            "RSET" => Ok(Self::Rset),
+            "NOOP" => Ok(Self::Noop),
+            "VRFY" => Ok(Self::Vrfy {
+                query: rest.to_owned(),
+            }),
+            "QUIT" => Ok(Self::Quit),
+            // RFC 2033 §4.1: HELO and EHLO are not valid in LMTP; all other verbs are unknown.
+            _ => Err(bad()),
+        }
     }
 }
 
@@ -158,4 +194,181 @@ pub enum MailParam {
 pub enum RcptParam {
     /// An unrecognised parameter preserved verbatim.
     Unknown(String),
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+trait StripPrefixCi {
+    fn strip_prefix_ci(&self, prefix: &str) -> Option<&str>;
+}
+
+impl StripPrefixCi for str {
+    fn strip_prefix_ci(&self, prefix: &str) -> Option<&str> {
+        (self.len() >= prefix.len() && self[..prefix.len()].eq_ignore_ascii_case(prefix))
+            .then(|| &self[prefix.len()..])
+    }
+}
+
+/// Split a `<path>` from any trailing SP+params, returning (path, params).
+fn split_path(s: &str) -> (&str, &str) {
+    if let Some(rest) = s.strip_prefix('<') {
+        // Angle-bracket delimited: find the closing '>'.
+        if let Some(close) = rest.find('>') {
+            let path = &s[..close + 2]; // include < and >
+            let params = rest[close + 1..].trim_start();
+            return (path, params);
+        }
+    }
+    // No angle brackets: path is everything up to first space.
+    match s.find(|c: char| c.is_ascii_whitespace()) {
+        Some(i) => (&s[..i], s[i + 1..].trim_start()),
+        None => (s, ""),
+    }
+}
+
+/// Parse a reverse-path string (`<>`, `<addr>`, or bare `addr`).
+fn parse_reverse_path(s: &str) -> Option<OwnedReversePath> {
+    let inner = s.trim();
+    if inner == "<>" {
+        return Some(OwnedReversePath::Null);
+    }
+    let addr_str = inner.trim_matches(|c| c == '<' || c == '>');
+    EmailAddress::parse(addr_str)
+        .ok()
+        .map(OwnedReversePath::Address)
+}
+
+/// Parse ESMTP parameters from the remainder after the path (RFC 5321 §4.1.2).
+fn parse_mail_params(s: &str) -> Vec<MailParam> {
+    s.split_ascii_whitespace()
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            if let Some(n) = p.strip_prefix_ci("SIZE=") {
+                n.parse::<u64>()
+                    .map_or_else(|_| MailParam::Unknown(p.to_owned()), MailParam::Size)
+            } else if p.eq_ignore_ascii_case("BODY=7BIT") {
+                MailParam::Body7Bit
+            } else if p.eq_ignore_ascii_case("BODY=8BITMIME") {
+                MailParam::Body8BitMime
+            } else {
+                MailParam::Unknown(p.to_owned())
+            }
+        })
+        .collect()
+}
+
+fn parse_rcpt_params(s: &str) -> Vec<RcptParam> {
+    s.split_ascii_whitespace()
+        .filter(|p| !p.is_empty())
+        .map(|p| RcptParam::Unknown(p.to_owned()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use email_primitives::address::OwnedReversePath;
+
+    use super::{Command, MailParam};
+
+    /// RFC 2033 §4.1: LHLO identifies the client.
+    #[test]
+    fn parse_lhlo() {
+        let cmd = Command::parse("LHLO example.com").expect("valid LHLO");
+        assert!(matches!(cmd, Command::Lhlo { .. }));
+    }
+
+    /// Case-insensitivity: verb may be lowercase (RFC 5321 §2.4).
+    #[test]
+    fn parse_lhlo_lowercase() {
+        let cmd = Command::parse("lhlo example.com").expect("lowercase lhlo");
+        assert!(matches!(cmd, Command::Lhlo { .. }));
+    }
+
+    /// RFC 5321 §4.1.1.2: MAIL FROM with null reverse-path.
+    #[test]
+    fn parse_mail_from_null() {
+        let cmd = Command::parse("MAIL FROM:<>").expect("null path");
+        assert!(matches!(
+            cmd,
+            Command::Mail {
+                from: OwnedReversePath::Null,
+                ..
+            }
+        ));
+    }
+
+    /// RFC 5321 §4.1.1.2: MAIL FROM with an address.
+    #[test]
+    fn parse_mail_from_addr() {
+        let cmd = Command::parse("MAIL FROM:<user@example.com>").expect("addr path");
+        assert!(matches!(
+            cmd,
+            Command::Mail {
+                from: OwnedReversePath::Address(_),
+                ..
+            }
+        ));
+    }
+
+    /// RFC 1870: SIZE parameter is parsed and converted to u64.
+    #[test]
+    fn parse_mail_from_size_param() {
+        let cmd = Command::parse("MAIL FROM:<user@example.com> SIZE=12345").expect("size param");
+        let Command::Mail { parameters, .. } = cmd else {
+            unreachable!("MAIL FROM:<> always produces the Mail variant");
+        };
+        assert!(parameters.contains(&MailParam::Size(12345)));
+    }
+
+    /// RFC 5321 §4.1.1.3: RCPT TO with a forward-path.
+    #[test]
+    fn parse_rcpt_to() {
+        let cmd = Command::parse("RCPT TO:<user@example.com>").expect("rcpt to");
+        assert!(matches!(cmd, Command::Rcpt { .. }));
+    }
+
+    /// RFC 5321 §4.1.1.4: DATA requires no arguments.
+    #[test]
+    fn parse_data() {
+        assert!(matches!(
+            Command::parse("DATA").expect("data"),
+            Command::Data
+        ));
+    }
+
+    /// RFC 5321 §4.1.1.5: RSET requires no arguments.
+    #[test]
+    fn parse_rset() {
+        assert!(matches!(
+            Command::parse("RSET").expect("rset"),
+            Command::Rset
+        ));
+    }
+
+    /// RFC 5321 §4.1.1.10: QUIT requires no arguments.
+    #[test]
+    fn parse_quit() {
+        assert!(matches!(
+            Command::parse("QUIT").expect("quit"),
+            Command::Quit
+        ));
+    }
+
+    /// RFC 2033 §4.1: HELO is not valid in LMTP.
+    #[test]
+    fn parse_helo_rejected() {
+        Command::parse("HELO example.com").expect_err("HELO must be rejected");
+    }
+
+    /// RFC 2033 §4.1: EHLO is not valid in LMTP.
+    #[test]
+    fn parse_ehlo_rejected() {
+        Command::parse("EHLO example.com").expect_err("EHLO must be rejected");
+    }
+
+    /// Unknown verbs are rejected.
+    #[test]
+    fn parse_unknown_rejected() {
+        Command::parse("FOOB example.com").expect_err("unknown verb rejected");
+    }
 }

--- a/crates/lmtp/src/session.rs
+++ b/crates/lmtp/src/session.rs
@@ -19,15 +19,17 @@
 //! protocol state machine decoupled from the application logic.
 //!
 //! After the complete message has been received, the session calls
-//! [`MessageHandler::handle`], which returns one [`crate::Reply`] per
+//! [`MessageHandler::handle`], which returns one [`Reply`] per
 //! recipient. The session then sends those replies in order.
 
-use crate::{Result, response::Reply};
+use crate::{Result, command::Command, response::Reply};
 use email_primitives::address::OwnedReversePath;
 use email_primitives::{EmailAddress, Message};
 
+use crate::Error;
+use crate::response::ReplyCode;
+
 /// The current state of an LMTP session.
-#[expect(dead_code, reason = "stub: used by handle_command() once implemented")]
 #[derive(Debug)]
 pub(crate) enum SessionState {
     /// TCP connection established; `220` greeting sent; waiting for `LHLO`.
@@ -55,6 +57,8 @@ pub(crate) enum SessionState {
         client_domain: email_primitives::Domain,
         /// The envelope sender.
         sender: OwnedReversePath,
+        /// ESMTP parameters from `MAIL FROM`.
+        mail_params: Vec<crate::command::MailParam>,
         /// Accepted recipients, in the order they were received.
         ///
         /// LMTP requires that per-recipient DATA responses are sent in the
@@ -68,12 +72,17 @@ pub(crate) enum SessionState {
         client_domain: email_primitives::Domain,
         /// The envelope sender.
         sender: OwnedReversePath,
+        /// ESMTP parameters from `MAIL FROM`.
+        mail_params: Vec<crate::command::MailParam>,
         /// The recipients awaiting per-message responses.
         recipients: Vec<EmailAddress>,
     },
 
     /// `QUIT` received; `221` sent; connection should be closed.
     Done,
+
+    /// Invalid state
+    Invalid,
 }
 
 /// Envelope information for a received message.
@@ -86,6 +95,8 @@ pub struct Envelope {
     pub sender: OwnedReversePath,
     /// The accepted `RCPT TO` addresses, in order.
     pub recipients: Vec<EmailAddress>,
+    /// ESMTP parameters from the `MAIL FROM` command.
+    pub mail_params: Vec<crate::command::MailParam>,
 }
 
 /// Outcome of processing a single recipient's delivery.
@@ -122,7 +133,7 @@ pub trait MessageHandler: Send + Sync {
         &self,
         envelope: Envelope,
         message: Message,
-    ) -> impl std::future::Future<Output = Result<Vec<RecipientResult>>> + Send;
+    ) -> impl Future<Output = Result<Vec<RecipientResult>>> + Send;
 }
 
 /// An LMTP session driving the protocol state machine over a framed transport.
@@ -134,9 +145,7 @@ pub trait MessageHandler: Send + Sync {
 pub struct Session<H: MessageHandler> {
     /// The server's hostname, used in greeting and `QUIT` responses.
     pub hostname: String,
-    #[expect(dead_code, reason = "stub: used by handle_command() once implemented")]
     state: SessionState,
-    #[expect(dead_code, reason = "stub: used by receive_data() once implemented")]
     handler: H,
 }
 
@@ -165,7 +174,7 @@ impl<H: MessageHandler> Session<H> {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::OutOfSequence`] if the command is not valid in
+    /// Returns [`Error::OutOfSequence`] if the command is not valid in
     /// the current session state.
     ///
     /// # State transitions
@@ -173,13 +182,144 @@ impl<H: MessageHandler> Session<H> {
     /// See the module-level state diagram.
     #[expect(
         clippy::unused_async,
-        reason = "stub: will await handler once implemented"
+        reason = "kept async for forward-compat; server calls it with .await"
     )]
-    pub async fn handle_command(&mut self, _command: crate::command::Command) -> Result<Reply> {
-        todo!(
-            "match self.state and command; transition state; \
-             return appropriate reply or Error::OutOfSequence"
-        )
+    pub async fn handle_command(&mut self, command: Command) -> Result<Reply> {
+        match command {
+            // NOOP is valid in any state and never changes it (RFC 5321 §4.1.1.9).
+            Command::Noop => Ok(Reply::ok()),
+            // VRFY is valid in any state and never changes it (RFC 5321 §4.1.1.6).
+            Command::Vrfy { .. } => Ok(Reply::new(ReplyCode::CANNOT_VRFY, "Cannot VRFY user")),
+            // QUIT is valid in any state (RFC 5321 §4.1.1.10).
+            Command::Quit => {
+                self.state = SessionState::Done;
+                Ok(Reply::closing(&self.hostname))
+            }
+            // RSET resets to Greeted from any post-LHLO state (RFC 5321 §4.1.1.5).
+            Command::Rset => {
+                let state = std::mem::replace(&mut self.state, SessionState::Invalid);
+                match state {
+                    SessionState::Greeted { client_domain }
+                    | SessionState::HasSender { client_domain, .. }
+                    | SessionState::HasRecipients { client_domain, .. } => {
+                        self.state = SessionState::Greeted { client_domain };
+                        Ok(Reply::ok())
+                    }
+                    other => {
+                        self.state = other;
+                        Err(Error::OutOfSequence(
+                            "RSET not valid in current state".into(),
+                        ))
+                    }
+                }
+            }
+            command => self.dispatch_command(command),
+        }
+    }
+
+    /// Dispatch a state-specific command (LHLO, MAIL, RCPT, DATA) through the
+    /// session state machine.
+    fn dispatch_command(&mut self, command: Command) -> Result<Reply> {
+        let state = std::mem::replace(&mut self.state, SessionState::Invalid);
+        let (state, response) = match (state, command) {
+            (SessionState::Connected, Command::Lhlo { client_domain }) => (
+                SessionState::Greeted { client_domain },
+                Ok(Reply::multi(
+                    ReplyCode::OK,
+                    vec![
+                        format!("{} Hello", self.hostname),
+                        "8BITMIME".to_owned(),
+                        "ENHANCEDSTATUSCODES".to_owned(),
+                    ],
+                )),
+            ),
+            (state @ SessionState::Connected, _) => (
+                state,
+                Err(Error::OutOfSequence(
+                    "expected LHLO before any other command".into(),
+                )),
+            ),
+            (SessionState::Greeted { client_domain }, Command::Mail { from, parameters }) => (
+                SessionState::HasSender {
+                    client_domain,
+                    sender: from,
+                    mail_params: parameters,
+                },
+                Ok(Reply::ok()),
+            ),
+            (state @ SessionState::Greeted { .. }, _) => (
+                state,
+                Err(Error::OutOfSequence("expected MAIL FROM".into())),
+            ),
+            (
+                SessionState::HasSender {
+                    client_domain,
+                    sender,
+                    mail_params,
+                },
+                Command::Rcpt { to, .. },
+            ) => (
+                SessionState::HasRecipients {
+                    client_domain,
+                    sender,
+                    mail_params,
+                    recipients: vec![to],
+                },
+                Ok(Reply::ok()),
+            ),
+            (state @ SessionState::HasSender { .. }, _) => {
+                (state, Err(Error::OutOfSequence("expected RCPT TO".into())))
+            }
+            (
+                SessionState::HasRecipients {
+                    client_domain,
+                    sender,
+                    mail_params,
+                    mut recipients,
+                },
+                Command::Rcpt { to, .. },
+            ) => {
+                recipients.push(to);
+                (
+                    SessionState::HasRecipients {
+                        client_domain,
+                        sender,
+                        mail_params,
+                        recipients,
+                    },
+                    Ok(Reply::ok()),
+                )
+            }
+            (
+                SessionState::HasRecipients {
+                    client_domain,
+                    sender,
+                    mail_params,
+                    recipients,
+                },
+                Command::Data,
+            ) => (
+                SessionState::Transferring {
+                    client_domain,
+                    sender,
+                    mail_params,
+                    recipients,
+                },
+                Ok(Reply::start_data()),
+            ),
+            (state @ SessionState::HasRecipients { .. }, _) => (
+                state,
+                Err(Error::OutOfSequence("expected RCPT TO or DATA".into())),
+            ),
+            (state, _) => (
+                state,
+                Err(Error::OutOfSequence(
+                    "command received in unexpected state".into(),
+                )),
+            ),
+        };
+        self.state = state;
+        response
     }
 
     /// Receive the complete message body (after the client has been sent `354`)
@@ -202,14 +342,153 @@ impl<H: MessageHandler> Session<H> {
     ///
     /// On success, resets to [`SessionState::Greeted`] so the client can begin
     /// a new transaction.
-    #[expect(
-        clippy::unused_async,
-        reason = "stub: will await handler once implemented"
-    )]
-    pub async fn receive_data(&mut self, _raw: bytes::Bytes) -> Result<Vec<Reply>> {
-        todo!(
-            "parse Message from raw bytes; call self.handler.handle(envelope, message); \
-             map RecipientResult to Reply vec; reset state to Greeted"
-        )
+    pub async fn receive_data(&mut self, raw: bytes::Bytes) -> Result<Vec<Reply>> {
+        let SessionState::Transferring {
+            client_domain,
+            sender,
+            mail_params,
+            recipients,
+        } = std::mem::replace(&mut self.state, SessionState::Invalid)
+        else {
+            return Err(Error::OutOfSequence(
+                "receive_data called outside Transferring state".into(),
+            ));
+        };
+
+        let greeted_domain = client_domain.clone();
+        let message = Message::parse(&raw)?;
+        let envelope = Envelope {
+            client_domain,
+            sender,
+            recipients,
+            mail_params,
+        };
+        let results = self.handler.handle(envelope, message).await?;
+        self.state = SessionState::Greeted {
+            client_domain: greeted_domain,
+        };
+        Ok(results.into_iter().map(|r| r.reply).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+
+    use super::{Envelope, MessageHandler, RecipientResult, Session};
+    use crate::{Command, Error, Reply, ReplyCode, Result};
+    use email_primitives::Message;
+
+    struct NoopHandler;
+
+    impl MessageHandler for NoopHandler {
+        async fn handle(
+            &self,
+            envelope: Envelope,
+            _message: Message,
+        ) -> Result<Vec<RecipientResult>> {
+            Ok(envelope
+                .recipients
+                .into_iter()
+                .map(|recipient| RecipientResult {
+                    recipient,
+                    reply: Reply::ok(),
+                })
+                .collect())
+        }
+    }
+
+    fn session() -> Session<NoopHandler> {
+        Session::new("mx.example.com", NoopHandler)
+    }
+
+    /// Greeting uses `SERVICE_READY` (220) and includes the hostname.
+    #[test]
+    fn greeting_reply() {
+        let s = session();
+        let r = s.greeting();
+        assert_eq!(r.code, ReplyCode::SERVICE_READY);
+        assert!(r.lines[0].contains("mx.example.com"));
+    }
+
+    /// LHLO in Connected state transitions to Greeted and returns 250.
+    #[tokio::test]
+    async fn lhlo_transitions_to_greeted() {
+        let mut s = session();
+        let cmd = Command::parse("LHLO client.example.com").expect("valid LHLO");
+        let reply = s.handle_command(cmd).await.expect("LHLO accepted");
+        assert!(reply.code.is_positive());
+    }
+
+    /// MAIL FROM in Connected state (before LHLO) returns `OutOfSequence`.
+    #[tokio::test]
+    async fn mail_before_lhlo_rejected() {
+        let mut s = session();
+        let cmd = Command::parse("MAIL FROM:<>").expect("valid MAIL");
+        let err = s.handle_command(cmd).await.expect_err("should be rejected");
+        assert!(matches!(err, Error::OutOfSequence(_)));
+    }
+
+    /// DATA before any RCPT TO (in `HasSender`) returns `OutOfSequence`.
+    #[tokio::test]
+    async fn data_before_rcpt_rejected() {
+        let mut s = session();
+        s.handle_command(Command::parse("LHLO client.example.com").expect("lhlo"))
+            .await
+            .expect("lhlo ok");
+        s.handle_command(Command::parse("MAIL FROM:<>").expect("mail"))
+            .await
+            .expect("mail ok");
+        let err = s
+            .handle_command(Command::parse("DATA").expect("data"))
+            .await
+            .expect_err("DATA before RCPT should fail");
+        assert!(matches!(err, Error::OutOfSequence(_)));
+    }
+
+    /// RSET from `HasRecipients` returns to Greeted (reply is 250).
+    #[tokio::test]
+    async fn rset_resets_to_greeted() {
+        let mut s = session();
+        s.handle_command(Command::parse("LHLO client.example.com").expect("lhlo"))
+            .await
+            .expect("lhlo ok");
+        s.handle_command(Command::parse("MAIL FROM:<>").expect("mail"))
+            .await
+            .expect("mail ok");
+        s.handle_command(Command::parse("RCPT TO:<user@example.com>").expect("rcpt"))
+            .await
+            .expect("rcpt ok");
+        let reply = s
+            .handle_command(Command::parse("RSET").expect("rset"))
+            .await
+            .expect("rset ok");
+        assert_eq!(reply.code, ReplyCode::OK);
+    }
+
+    /// Full transaction: LHLO → MAIL → RCPT → DATA → `receive_data`.
+    #[tokio::test]
+    async fn full_transaction() {
+        let mut s = session();
+        s.handle_command(Command::parse("LHLO client.example.com").expect("lhlo"))
+            .await
+            .expect("lhlo");
+        s.handle_command(Command::parse("MAIL FROM:<sender@example.com>").expect("mail"))
+            .await
+            .expect("mail");
+        s.handle_command(Command::parse("RCPT TO:<rcpt@example.com>").expect("rcpt"))
+            .await
+            .expect("rcpt");
+        let data_reply = s
+            .handle_command(Command::parse("DATA").expect("data"))
+            .await
+            .expect("data");
+        assert_eq!(data_reply.code, ReplyCode::START_MAIL_INPUT);
+
+        // Minimal valid RFC 5322 message.
+        let raw = Bytes::from("Subject: test\r\n\r\nbody\r\n");
+        let replies = s.receive_data(raw).await.expect("receive_data");
+        assert_eq!(replies.len(), 1);
+        assert!(replies[0].code.is_positive());
     }
 }


### PR DESCRIPTION
Fills in Command::parse (case-insensitive verb dispatch, MAIL/RCPT path parsing, ESMTP parameter parsing, RFC 2033 §4.1 HELO/EHLO rejection), Session::handle_command (RFC 2033 state machine with early returns for NOOP/VRFY/QUIT/RSET), and Session::receive_data (Message::parse → MessageHandler::handle → per-recipient replies). Adds 16 unit tests across command parsing and session state transitions.

https://claude.ai/code/session_01DZn9DzGvWzsw9M6vgkvzkr