### PR TITLE
lmtp/server: implement run_session and receive_body (step 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -765,6 +766,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "email-primitives",
+ "futures-util",
  "thiserror",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ dkim              = { path = "crates/dkim" }
 arc               = { path = "crates/arc" }
 
 # Async runtime (tokio 1.x is the de-facto standard async runtime)
-tokio      = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio        = { version = "1", features = ["full"] }
+tokio-util   = { version = "0.7", features = ["codec"] }
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 
 # Byte buffers
 bytes = "1"

--- a/crates/email-primitives/src/error.rs
+++ b/crates/email-primitives/src/error.rs
@@ -18,7 +18,10 @@ pub enum Error {
 
     /// An email address could not be parsed per RFC 5321 section 4.1.2.
     #[error("invalid email address: {0:?}")]
-    InvalidAddress(String, #[source] Option<Box<dyn std::error::Error>>),
+    InvalidAddress(
+        String,
+        #[source] Option<Box<dyn std::error::Error + Send + Sync>>,
+    ),
 
     /// A domain name was syntactically invalid (RFC 5321 section 4.1.2,
     /// RFC 1123 section 2.1).

--- a/crates/lmtp/Cargo.toml
+++ b/crates/lmtp/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 email-primitives = { workspace = true }
 bytes            = { workspace = true }
+futures-util     = { workspace = true }
 thiserror        = { workspace = true }
 tokio            = { workspace = true }
 tokio-util       = { workspace = true }

--- a/crates/lmtp/src/codec.rs
+++ b/crates/lmtp/src/codec.rs
@@ -19,7 +19,7 @@
 //!   `String` (the line, without the CRLF).
 //!
 //! - [`DataCodec`]: accumulates bytes until `\r\n.\r\n`, applies dot-
-//!   unstuffing, and returns the complete message body as [`bytes::Bytes`].
+//!   unstuffing, and returns the complete message body as [`Bytes`].
 //!
 //! The [`crate::server`] and [`crate::session`] layers are responsible for
 //! swapping the active codec at the appropriate point in the conversation.
@@ -34,10 +34,11 @@
 //! We enforce command-line limits in [`CommandCodec`] and data-line limits in
 //! [`DataCodec`] to protect against resource exhaustion.
 
-use bytes::{Buf, BufMut, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::io;
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::{Error, Result};
+use crate::{Error, Reply, Result};
 
 /// Maximum command/reply line length including CRLF (RFC 5321 §4.5.3.1).
 pub const MAX_COMMAND_LINE: usize = 512;
@@ -79,8 +80,8 @@ impl Decoder for CommandCodec {
         let Some(lf_pos) = src.iter().position(|&b| b == b'\n') else {
             // No complete line yet; enforce length limit against partial data.
             if src.len() >= self.max_line {
-                return Err(Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
+                return Err(Error::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
                     "command line too long",
                 )));
             }
@@ -90,8 +91,8 @@ impl Decoder for CommandCodec {
         // +1 to include the LF itself in the length check.
         let line_len = lf_pos + 1;
         if line_len > self.max_line {
-            return Err(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
                 "command line too long",
             )));
         }
@@ -106,8 +107,8 @@ impl Decoder for CommandCodec {
 
         let line = std::str::from_utf8(&line_bytes)
             .map_err(|_utf8_err| {
-                Error::Io(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
+                Error::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
                     "command line is not valid UTF-8",
                 ))
             })?
@@ -128,10 +129,21 @@ impl Encoder<&str> for CommandCodec {
     }
 }
 
+impl Encoder<Reply> for CommandCodec {
+    type Error = Error;
+
+    fn encode(&mut self, item: Reply, dst: &mut BytesMut) -> Result<()> {
+        let wire = item.to_wire();
+        dst.reserve(wire.len());
+        dst.put(wire.as_bytes());
+        Ok(())
+    }
+}
+
 /// Decodes a SMTP/LMTP `DATA` body terminated by `\\r\\n.\\r\\n`.
 ///
 /// Applies dot-unstuffing: if a line begins with `..`, the leading `.` is
-/// stripped. Returns the complete unstuffed body as [`bytes::Bytes`] once the
+/// stripped. Returns the complete unstuffed body as [`Bytes`] once the
 /// terminator is seen.
 #[derive(Debug)]
 pub struct DataCodec {
@@ -147,14 +159,22 @@ impl DataCodec {
     }
 }
 
+impl Encoder<Bytes> for DataCodec {
+    type Error = Error;
+
+    fn encode(&mut self, _item: Bytes, _dst: &mut BytesMut) -> Result<()> {
+        Ok(())
+    }
+}
+
 impl Decoder for DataCodec {
-    type Item = bytes::Bytes;
+    type Item = Bytes;
     type Error = Error;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>> {
         if src.len() > self.max_size {
-            return Err(Error::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(Error::Io(io::Error::new(
+                io::ErrorKind::InvalidData,
                 "message too large",
             )));
         }
@@ -175,7 +195,7 @@ impl Decoder for DataCodec {
         src.advance(consumed_end);
 
         let unstuffed = dot_unstuff(&raw_body);
-        Ok(Some(bytes::Bytes::from(unstuffed)))
+        Ok(Some(Bytes::from(unstuffed)))
     }
 }
 

--- a/crates/lmtp/src/server.rs
+++ b/crates/lmtp/src/server.rs
@@ -1,7 +1,7 @@
 //! LMTP server listener.
 //!
 //! The [`Server`] binds to a TCP address or a Unix domain socket and spawns a
-//! tokio task per connection. Each task runs a [`crate::Session`] to completion.
+//! tokio task per connection. Each task runs a [`Session`] to completion.
 //!
 //! # Connection flow per client
 //!
@@ -18,7 +18,7 @@
 //!         session.receive_data() ─▶ returns Vec<Reply>
 //!         send each reply in order
 //!     if QUIT:
-//!         break
+//!         send 221 and return
 //! }
 //! close connection
 //! ```
@@ -31,11 +31,22 @@
 
 use std::sync::Arc;
 
+use futures_util::{SinkExt, StreamExt};
 use tokio::net::{TcpListener, UnixListener};
-use tracing::{error, info};
+use tokio_util::codec::{Framed, FramedParts};
+use tracing::{error, info, warn};
 
-use crate::Result;
-use crate::session::MessageHandler;
+use crate::codec::{CommandCodec, DataCodec};
+use crate::command::Command;
+use crate::response::ReplyCode;
+use crate::session::{MessageHandler, Session};
+use crate::{Error, Reply, Result};
+
+trait ReadWriteStream: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static {}
+impl<S> ReadWriteStream for S where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static
+{
+}
 
 /// Configuration for the LMTP server.
 #[non_exhaustive]
@@ -44,7 +55,7 @@ pub struct ServerConfig {
     /// The hostname to announce in the `220` greeting and `221` closing.
     pub hostname: String,
 
-    /// Maximum accepted message size in bytes (enforced in [`crate::codec::DataCodec`]).
+    /// Maximum accepted message size in bytes (enforced in [`DataCodec`]).
     ///
     /// Advertised via the `SIZE` extension in `LHLO` responses (RFC 1870).
     pub max_message_size: usize,
@@ -70,12 +81,12 @@ impl Default for ServerConfig {
 ///
 /// The `H` type is cloned (or Arc'd) for each accepted connection so that
 /// connections can run concurrently.
-pub struct Server<H: MessageHandler + Clone + 'static> {
+pub struct Server<H: MessageHandler> {
     config: ServerConfig,
     handler: H,
 }
 
-impl<H: MessageHandler + Clone + 'static> Server<H> {
+impl<H: MessageHandler> Server<H> {
     /// Construct a new server with the given configuration and message handler.
     #[must_use]
     pub const fn new(config: ServerConfig, handler: H) -> Self {
@@ -129,20 +140,223 @@ impl<H: MessageHandler + Clone + 'static> Server<H> {
     ///
     /// `S` must implement both `AsyncRead` and `AsyncWrite` (satisfied by
     /// `TcpStream` and `UnixStream`).
-    #[expect(
-        clippy::unused_async,
-        reason = "stub: will drive framed session once implemented"
-    )]
-    async fn run_session<S>(_config: Arc<ServerConfig>, _handler: H, _stream: S) -> Result<()>
-    where
-        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    {
-        todo!(
-            "wrap stream in Framed<CommandCodec>; send greeting; \
-             loop: decode command, call session.handle_command(), send reply; \
-             on DATA: switch to DataCodec, decode body, call session.receive_data(), \
-             send per-recipient replies, switch back to CommandCodec; \
-             on QUIT: send 221 and return Ok(())"
-        )
+    async fn run_session<S: ReadWriteStream>(
+        config: Arc<ServerConfig>,
+        handler: H,
+        stream: S,
+    ) -> Result<()> {
+        let mut session = Session::new(&config.hostname, handler);
+        let mut framed = Framed::new(stream, CommandCodec::new());
+
+        // RFC 2033 §4: server sends 220 greeting immediately after connection.
+        framed.send(session.greeting()).await?;
+
+        loop {
+            if let Some(frame) = framed.next().await {
+                let line = frame?;
+
+                let cmd = match Command::parse(&line) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(error = %e, "bad command from client");
+                        framed.send(Reply::syntax_error()).await?;
+                        continue;
+                    }
+                };
+
+                let is_data = matches!(cmd, Command::Data);
+
+                let reply = match session.handle_command(cmd).await {
+                    Ok(r) => r,
+                    Err(Error::OutOfSequence(msg)) => {
+                        warn!("out of sequence: {msg}");
+                        framed.send(Reply::bad_sequence()).await?;
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                };
+
+                let done = reply.code == ReplyCode::SERVICE_CLOSING;
+                framed.send(reply).await?;
+                if done {
+                    return Ok(());
+                }
+
+                if is_data {
+                    framed = Self::receive_body(framed, &mut session, &config).await?;
+                }
+            } else {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Switch to [`DataCodec`], read the message body, call [`Session::receive_data`],
+    /// send per-recipient replies, then switch back to [`CommandCodec`].
+    async fn receive_body<S: ReadWriteStream>(
+        framed: Framed<S, CommandCodec>,
+        session: &mut Session<H>,
+        config: &ServerConfig,
+    ) -> Result<Framed<S, CommandCodec>> {
+        // Carry over buffered bytes so no data is lost between codec switches.
+        let FramedParts {
+            io,
+            read_buf,
+            write_buf,
+            ..
+        } = framed.into_parts();
+        let mut data_parts = FramedParts::new(io, DataCodec::new(config.max_message_size));
+        data_parts.read_buf = read_buf;
+        data_parts.write_buf = write_buf;
+        let mut data_framed = Framed::from_parts(data_parts);
+
+        let raw = match data_framed.next().await {
+            None => {
+                return Err(Error::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "client closed connection during DATA",
+                )));
+            }
+            Some(Err(e)) => return Err(e),
+            Some(Ok(b)) => b,
+        };
+
+        let replies = session.receive_data(raw).await?;
+
+        // Switch back to CommandCodec, carrying over any buffered bytes.
+        let FramedParts {
+            io,
+            read_buf,
+            write_buf,
+            ..
+        } = data_framed.into_parts();
+        let mut cmd_parts = FramedParts::new::<Reply>(io, CommandCodec::new());
+        cmd_parts.read_buf = read_buf;
+        cmd_parts.write_buf = write_buf;
+        let mut cmd_framed = Framed::from_parts(cmd_parts);
+
+        for reply in replies {
+            cmd_framed.send(reply).await?;
+        }
+
+        Ok(cmd_framed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
+
+    use super::{Server, ServerConfig};
+    use crate::session::{Envelope, MessageHandler, RecipientResult};
+    use crate::{Reply, Result};
+    use email_primitives::Message;
+
+    #[derive(Clone)]
+    struct OkHandler;
+
+    impl MessageHandler for OkHandler {
+        async fn handle(
+            &self,
+            envelope: Envelope,
+            _message: Message,
+        ) -> Result<Vec<RecipientResult>> {
+            Ok(envelope
+                .recipients
+                .into_iter()
+                .map(|recipient| RecipientResult {
+                    recipient,
+                    reply: Reply::ok(),
+                })
+                .collect())
+        }
+    }
+
+    /// Run a canned client script against a single session and return server output.
+    ///
+    /// Writes all `script` bytes upfront (they fit in the duplex buffer), runs
+    /// the session to completion, then returns everything the server wrote.
+    async fn run(script: &[u8]) -> String {
+        let (mut client, server) = duplex(65536);
+        let config = Arc::new(ServerConfig::default());
+        client
+            .write_all(script)
+            .await
+            .expect("write script to duplex");
+        // Drop write half by calling shutdown; the server sees EOF after QUIT.
+        client.shutdown().await.expect("shutdown write");
+        Server::<OkHandler>::run_session(config, OkHandler, server)
+            .await
+            .expect("session ok");
+        let mut output = String::new();
+        client
+            .read_to_string(&mut output)
+            .await
+            .expect("read server output");
+        output
+    }
+
+    /// RFC 2033 §4: server sends 220 greeting on connect.
+    #[tokio::test]
+    async fn greeting_sent() {
+        let out = run(b"QUIT\r\n").await;
+        assert!(
+            out.starts_with("220 "),
+            "expected 220 greeting, got: {out:?}"
+        );
+    }
+
+    /// LHLO is accepted with 250.
+    #[tokio::test]
+    async fn lhlo_accepted() {
+        let out = run(b"LHLO client.example.com\r\nQUIT\r\n").await;
+        assert!(out.contains("250 "), "expected 250 for LHLO, got: {out:?}");
+    }
+
+    /// QUIT sends 221 and ends the session.
+    #[tokio::test]
+    async fn quit_closes() {
+        let out = run(b"QUIT\r\n").await;
+        assert!(out.contains("221 "), "expected 221 for QUIT, got: {out:?}");
+    }
+
+    /// Unknown verb gets 500, then QUIT still works (RFC 5321 §4.2.5).
+    #[tokio::test]
+    async fn syntax_error_recovery() {
+        let out = run(b"GARBAGE here\r\nQUIT\r\n").await;
+        assert!(
+            out.contains("500 "),
+            "expected 500 for bad verb, got: {out:?}"
+        );
+        assert!(
+            out.contains("221 "),
+            "expected 221 after recovery, got: {out:?}"
+        );
+    }
+
+    /// Full DATA transfer: LHLO → MAIL → RCPT → DATA → body → 250 per recipient.
+    #[tokio::test]
+    async fn full_data_transfer() {
+        let script = b"LHLO client.example.com\r\n\
+                       MAIL FROM:<sender@example.com>\r\n\
+                       RCPT TO:<rcpt@example.com>\r\n\
+                       DATA\r\n\
+                       Subject: test\r\n\
+                       \r\n\
+                       body text\r\n\
+                       .\r\n\
+                       QUIT\r\n";
+        let out = run(script).await;
+        assert!(
+            out.contains("354 "),
+            "expected 354 start-data, got: {out:?}"
+        );
+        assert!(
+            out.matches("250 ").count() >= 2,
+            "expected ≥2 250 replies (LHLO+MAIL+RCPT+DATA), got: {out:?}"
+        );
+        assert!(out.contains("221 "), "expected 221 for QUIT, got: {out:?}");
     }
 }

--- a/crates/lmtp/src/session.rs
+++ b/crates/lmtp/src/session.rs
@@ -124,7 +124,7 @@ pub struct RecipientResult {
 /// This trait uses `async fn` in trait position (stabilised in Rust 1.75 via
 /// RPITIT). Implementations may perform async I/O (DNS, downstream LMTP,
 /// signing).
-pub trait MessageHandler: Send + Sync {
+pub trait MessageHandler: Send + Sync + Clone + 'static {
     /// Process a received message and return per-recipient outcomes.
     ///
     /// The returned `Vec` must have the same length as `envelope.recipients`
@@ -379,6 +379,7 @@ mod tests {
     use crate::{Command, Error, Reply, ReplyCode, Result};
     use email_primitives::Message;
 
+    #[derive(Clone)]
     struct NoopHandler;
 
     impl MessageHandler for NoopHandler {


### PR DESCRIPTION
Wire CommandCodec and DataCodec into a full per-connection driver. run_session drives the LMTP state machine over any AsyncRead+AsyncWrite stream: sends the 220 greeting, loops reading commands, switches to DataCodec for the DATA body, invokes the MessageHandler, and sends per-recipient replies.

Also add Encoder<bytes::Bytes> for DataCodec (required by FramedParts::new), and fix email_primitives::Error::InvalidAddress to use Box<dyn Error + Send + Sync> so the Error type is Send and futures spawned via tokio::spawn compile cleanly.

https://claude.ai/code/session_01DZn9DzGvWzsw9M6vgkvzkr